### PR TITLE
Release v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version changelog
 
+## ## 0.0.1
+
+* Added `.codegen.json` and `CHANGELOG.md` templates for automated releases.
+* Added `CODEOWNERS` for code governance.
+* Added command framework for Databricks CLI launcher frontend ([#10](https://github.com/databrickslabs/blueprint/pull/10)).
+* Added ProductInfo unreleased version fallback ([#9](https://github.com/databrickslabs/blueprint/pull/9)).
 ## 0.0.0
 
 Initial commit


### PR DESCRIPTION

* Added `.codegen.json` and `CHANGELOG.md` templates for automated releases.
* Added `CODEOWNERS` for code governance.
* Added command framework for Databricks CLI launcher frontend ([#10](https://github.com/databrickslabs/blueprint/pull/10)).
* Added ProductInfo unreleased version fallback ([#9](https://github.com/databrickslabs/blueprint/pull/9)).
