### PR TITLE
Added brute-forcing `SerdeError` with `as_dict()` and `from_dict()`

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -2,7 +2,7 @@ name: acceptance
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
 
 permissions:
   id-token: write

--- a/src/databricks/labs/blueprint/installation.py
+++ b/src/databricks/labs/blueprint/installation.py
@@ -546,7 +546,7 @@ class Installation:
     class _FromDict(Protocol):
         @classmethod
         def from_dict(cls, raw: dict):
-            ...
+            pass
 
     @classmethod
     def _unmarshal(cls, inst: Any, path: list[str], type_ref: type[T]) -> T | None:

--- a/src/databricks/labs/blueprint/installation.py
+++ b/src/databricks/labs/blueprint/installation.py
@@ -13,7 +13,15 @@ from collections.abc import Callable, Collection
 from functools import partial
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, BinaryIO, TypeVar, get_args, get_type_hints
+from typing import (
+    Any,
+    BinaryIO,
+    Protocol,
+    TypeVar,
+    get_args,
+    get_type_hints,
+    runtime_checkable,
+)
 
 import databricks.sdk.core
 from databricks.sdk import WorkspaceClient
@@ -455,6 +463,8 @@ class Installation:
             return cls._marshal_databricks_config(inst)
         if type_ref in cls._PRIMITIVES:
             return inst, True
+        if hasattr(inst, "as_dict"):
+            return inst.as_dict(), True
         raise SerdeError(f'{".".join(path)}: unknown: {inst}')
 
     @classmethod
@@ -532,6 +542,12 @@ class Installation:
             return None, False
         return inst.value, True
 
+    @runtime_checkable
+    class _FromDict(Protocol):
+        @classmethod
+        def from_dict(cls, raw: dict):
+            ...
+
     @classmethod
     def _unmarshal(cls, inst: Any, path: list[str], type_ref: type[T]) -> T | None:
         # pylint: disable-next=import-outside-toplevel
@@ -562,6 +578,8 @@ class Installation:
             return databricks.sdk.core.Config(**inst)  # type: ignore[return-value]
         if type_ref == types.NoneType:
             return None
+        if isinstance(type_ref, cls._FromDict):
+            return type_ref.from_dict(inst)
         raise SerdeError(f'{".".join(path)}: unknown: {type_ref}: {inst}')
 
     @classmethod

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -356,3 +356,32 @@ def test_upload_feature_disabled_failure():
     installation.save(WorkspaceConfig(inventory_database="some_blueprint"))
 
     ws.workspace.mkdirs.assert_called_with("/Users/foo/.blueprint")
+
+
+class SomePolicy:
+    def __init__(self, a, b):
+        self._a = a
+        self._b = b
+
+    def as_dict(self):
+        return {"a": self._a, "b": self._b}
+
+    @classmethod
+    def from_dict(cls, raw):
+        return cls(raw.get("a"), raw.get("b"))
+
+    def __eq__(self, o):
+        assert isinstance(o, SomePolicy)
+        return self._a == o._a and self._b == o._b
+
+
+def test_as_dict_serde():
+    installation = MockInstallation()
+
+    policy = SomePolicy(1, 2)
+    installation.save(policy, filename="backups/policy-123.json")
+
+    installation.assert_file_written("backups/policy-123.json", {"a": 1, "b": 2})
+
+    load = installation.load(SomePolicy, filename="backups/policy-123.json")
+    assert load == policy


### PR DESCRIPTION
In the rare circumstances when you cannot use [@dataclass](#loading-dataclass-configuration) or you get `SerdeError` that you cannot explain, you can implement `from_dict(cls, raw: dict) -> 'T'` and `as_dict(self) -> dict` methods on the class:

```python
from databricks.sdk import WorkspaceClient
from databricks.labs.blueprint.installation import Installation

class SomePolicy:
    def __init__(self, a, b):
        self._a = a
        self._b = b

    def as_dict(self) -> dict:
        return {"a": self._a, "b": self._b}

    @classmethod
    def from_dict(cls, raw: dict):
        return cls(raw.get("a"), raw.get("b"))

    def __eq__(self, o):
        assert isinstance(o, SomePolicy)
        return self._a == o._a and self._b == o._b

policy = SomePolicy(1, 2)
installation = Installation.current(WorkspaceClient(), "blueprint")
installation.save(policy, filename="backups/policy-123.json")
load = installation.load(SomePolicy, filename="backups/policy-123.json")

assert load == policy
```