### PR TITLE
Fixed the order of marshal to handle Dataclass with as_dict before other types to avoid SerdeError

### DIFF
--- a/src/databricks/labs/blueprint/installation.py
+++ b/src/databricks/labs/blueprint/installation.py
@@ -443,6 +443,8 @@ class Installation:
             _UnionGenericAlias,
         )
 
+        if hasattr(inst, "as_dict"):
+            return inst.as_dict(), True
         if dataclasses.is_dataclass(type_ref):
             return cls._marshal_dataclass(type_ref, path, inst)
         if isinstance(type_ref, types.GenericAlias):
@@ -463,8 +465,7 @@ class Installation:
             return cls._marshal_databricks_config(inst)
         if type_ref in cls._PRIMITIVES:
             return inst, True
-        if hasattr(inst, "as_dict"):
-            return inst.as_dict(), True
+
         raise SerdeError(f'{".".join(path)}: unknown: {inst}')
 
     @classmethod

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -385,3 +385,21 @@ def test_as_dict_serde():
 
     load = installation.load(SomePolicy, filename="backups/policy-123.json")
     assert load == policy
+
+
+@dataclass
+class Policy:
+    policy_id: str
+    name: str
+
+    def as_dict(self) -> dict:
+        return {"policy_id": self.policy_id, "name": self.name}
+
+
+def test_data_class():
+    installation = MockInstallation()
+    policy = Policy("123", "foo")
+    installation.save(policy, filename="backups/policy-test.json")
+    installation.assert_file_written("backups/policy-test.json", {"policy_id": "123", "name": "foo"})
+    load = installation.load(Policy, filename="backups/policy-test.json")
+    assert load == policy


### PR DESCRIPTION
Situation:
While doing the installation.save with a Dataclass object, it goes to the cls._marshal_dataclass(type_ref, path, inst) which results in SerdeError. 
Fix:
Change the order of evaluation and bring the below code in the beginning
if hasattr(inst, "as_dict"):
            return inst.as_dict(), True

How it's tested:
Unit tested with sample Dataclass and it works