### PR TITLE
Added commands with interactive prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Baseline for Databricks Labs projects written in Python. Sources are validated w
     * [Publishing Wheels to Databricks Workspace](#publishing-wheels-to-databricks-workspace)
   * [Databricks CLI's `databricks labs ...` Router](#databricks-clis-databricks-labs--router)
     * [Account-level Commands](#account-level-commands)
+    * [Commands with interactive prompts](#commands-with-interactive-prompts)
     * [Integration with Databricks Connect](#integration-with-databricks-connect)
     * [Starting New Projects](#starting-new-projects)
 * [Notable Downstream Projects](#notable-downstream-projects)
@@ -73,6 +74,8 @@ This library contains a proven set of building blocks, tested in production thro
 Your command-line apps do need testable interactivity, which is provided by `from databricks.labs.blueprint.tui import Prompts`. Here are some examples of it:
 
 ![ucx install](docs/ucx-install.gif)
+
+It is also integrated with our [command router](#commands-with-interactive-prompts). 
 
 [[back to top](#databricks-labs-blueprint)]
 
@@ -998,6 +1001,32 @@ def workspaces(a: AccountClient):
     """Shows workspaces"""
     for ws in a.workspaces.list():
         logger.info(f"Workspace: {ws.workspace_name} ({ws.workspace_id})")
+```
+
+[[back to top](#databricks-labs-blueprint)]
+
+### Commands with interactive prompts
+
+If your command needs some terminal interactivity, simply add [`prompts: Prompts` argument](#basic-terminal-user-interface-tui-primitives) to your command:
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.labs.blueprint.entrypoint import get_logger
+from databricks.labs.blueprint.cli import App
+from databricks.labs.blueprint.tui import Prompts
+
+app = App(__file__)
+logger = get_logger(__file__)
+
+
+@app.command
+def me(w: WorkspaceClient, prompts: Prompts):
+    """Shows current username"""
+    if prompts.confirm("Are you sure?"):
+        logger.info(f"Hello, {w.current_user.me().user_name}!")
+
+if "__main__" == __name__:
+    app()
 ```
 
 [[back to top](#databricks-labs-blueprint)]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,6 +4,17 @@ import sys
 from unittest import mock
 
 from databricks.labs.blueprint.cli import App
+from databricks.labs.blueprint.tui import Prompts
+
+FOO_COMMAND = json.dumps(
+    {
+        "command": "foo",
+        "flags": {
+            "name": "y",
+            "log_level": "disabled",
+        },
+    }
+)
 
 
 def test_commands():
@@ -15,22 +26,23 @@ def test_commands():
         """Some comment"""
         some(name)
 
-    with mock.patch.object(
-        sys,
-        "argv",
-        [
-            ...,
-            json.dumps(
-                {
-                    "command": "foo",
-                    "flags": {
-                        "name": "y",
-                        "log_level": "disabled",
-                    },
-                }
-            ),
-        ],
-    ):
+    with mock.patch.object(sys, "argv", [..., FOO_COMMAND]):
+        app()
+
+    some.assert_called_with("y")
+
+
+def test_injects_prompts():
+    some = mock.Mock()
+    app = App(inspect.getfile(App))
+
+    @app.command(is_unauthenticated=True)
+    def foo(name: str, prompts: Prompts):
+        """Some comment"""
+        assert isinstance(prompts, Prompts)
+        some(name)
+
+    with mock.patch.object(sys, "argv", [..., FOO_COMMAND]):
         app()
 
     some.assert_called_with("y")


### PR DESCRIPTION
If your command needs some terminal interactivity, simply add [`prompts: Prompts` argument](#basic-terminal-user-interface-tui-primitives) to your command:

```python
from databricks.sdk import WorkspaceClient
from databricks.labs.blueprint.entrypoint import get_logger
from databricks.labs.blueprint.cli import App
from databricks.labs.blueprint.tui import Prompts

app = App(__file__)
logger = get_logger(__file__)

@app.command
def me(w: WorkspaceClient, prompts: Prompts):
    """Shows current username"""
    if prompts.confirm("Are you sure?"):
        logger.info(f"Hello, {w.current_user.me().user_name}!")

if "__main__" == __name__:
    app()
```

Fix #49