### PR TITLE
Improved `MockPrompts` with `extend()` method

### DIFF
--- a/src/databricks/labs/blueprint/tui.py
+++ b/src/databricks/labs/blueprint/tui.py
@@ -1,5 +1,7 @@
 """Text User Interface (TUI) utilities"""
 
+from __future__ import annotations
+
 import logging
 import re
 from collections.abc import Callable
@@ -144,8 +146,10 @@ class MockPrompts(Prompts):
             return answer
         raise ValueError(f"not mocked: {text}")
 
-    def extend(self, patterns_to_answers: dict[str, str]):
+    def extend(self, patterns_to_answers: dict[str, str]) -> MockPrompts:
         """Extend the existing list of questions and answers"""
         patterns = [(re.compile(k), v) for k, v in patterns_to_answers.items()]
         self._questions_to_answers.extend(patterns)
         self._questions_to_answers.sort(key=lambda _: len(_[0].pattern), reverse=True)
+
+        return self

--- a/src/databricks/labs/blueprint/tui.py
+++ b/src/databricks/labs/blueprint/tui.py
@@ -143,3 +143,9 @@ class MockPrompts(Prompts):
                 return default
             return answer
         raise ValueError(f"not mocked: {text}")
+
+    def extend(self, patterns_to_answers: dict[str, str]):
+        """Extend the existing list of questions and answers"""
+        patterns = [(re.compile(k), v) for k, v in patterns_to_answers.items()]
+        self._questions_to_answers.extend(patterns)
+        self._questions_to_answers.sort(key=lambda _: len(_[0].pattern), reverse=True)

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -28,3 +28,19 @@ def test_ask_for_int():
     prompts = MockPrompts({r".*": ""})
     res = prompts.question("Number of threads", default="8", valid_number=True)
     assert "8" == res
+
+
+def test_extend_prompts():
+    prompts = MockPrompts({r"initial_question": "initial_answer"})
+    res = prompts.question("initial_question")
+    assert "initial_answer" == res
+
+    with pytest.raises(ValueError) as err:
+        prompts.question("new_question")
+    assert "not mocked: new_question" == err.value.args[0]
+
+    prompts.extend({r"new_question": "new_answer"})
+    res = prompts.question("new_question")
+    assert "new_answer" == res
+
+

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -39,8 +39,6 @@ def test_extend_prompts():
         prompts.question("new_question")
     assert "not mocked: new_question" == err.value.args[0]
 
-    prompts.extend({r"new_question": "new_answer"})
+    prompts = prompts.extend({r"new_question": "new_answer"})
     res = prompts.question("new_question")
     assert "new_answer" == res
-
-


### PR DESCRIPTION
Useful for writing tests that involve changing prompt answers