### PR TITLE
`MockPrompts.extend()` now returns a copy

### DIFF
--- a/src/databricks/labs/blueprint/tui.py
+++ b/src/databricks/labs/blueprint/tui.py
@@ -148,8 +148,8 @@ class MockPrompts(Prompts):
 
     def extend(self, patterns_to_answers: dict[str, str]) -> MockPrompts:
         """Extend the existing list of questions and answers"""
-        patterns = [(re.compile(k), v) for k, v in patterns_to_answers.items()]
-        self._questions_to_answers.extend(patterns)
-        self._questions_to_answers.sort(key=lambda _: len(_[0].pattern), reverse=True)
-
-        return self
+        new_patterns_to_answers = {
+            **{pattern.pattern: answer for pattern, answer in self._questions_to_answers},
+            **patterns_to_answers,
+        }
+        return MockPrompts(new_patterns_to_answers)

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -32,13 +32,20 @@ def test_ask_for_int():
 
 def test_extend_prompts():
     prompts = MockPrompts({r"initial_question": "initial_answer"})
+
+    # Test that the initial question is mocked
     res = prompts.question("initial_question")
     assert "initial_answer" == res
 
-    with pytest.raises(ValueError) as err:
+    # Test that the new question is not mocked
+    with pytest.raises(ValueError, match="not mocked: new_question"):
         prompts.question("new_question")
-    assert "not mocked: new_question" == err.value.args[0]
 
-    prompts = prompts.extend({r"new_question": "new_answer"})
-    res = prompts.question("new_question")
+    # Test that the new question is mocked after using extend
+    new_prompts = prompts.extend({r"new_question": "new_answer"})
+    res = new_prompts.question("new_question")
     assert "new_answer" == res
+
+    # Test that new question is still not mocked in the original prompts
+    with pytest.raises(ValueError, match="not mocked: new_question"):
+        prompts.question("new_question")


### PR DESCRIPTION
extend method in MockPrompts would modify the state of the original MockPrompts. Changing it to return a copy instead so that the original prompts can be re-used in multiple places in the same test.