### PR TITLE
If `Threads.strict()` raises just one error, don't wrap it with `ManyError`

### DIFF
--- a/src/databricks/labs/blueprint/installer.py
+++ b/src/databricks/labs/blueprint/installer.py
@@ -64,15 +64,18 @@ class InstallState:
     def __getattr__(self, item: str) -> dict[str, str]:
         with self._lock:
             if not self._state:
-                try:
-                    self._state = self._installation.load(RawState)
-                except NotFound:
-                    self._state = RawState(resources={})
+                self._state = self._load_state()
         if not self._state:
             raise StateError("Failed to load raw state")
         if item not in self._state.resources:
             self._state.resources[item] = {}
         return self._state.resources[item]
+
+    def _load_state(self) -> RawState:
+        try:
+            return self._installation.load(RawState)
+        except NotFound:
+            return RawState(resources={})
 
     def save(self) -> None:
         """Saves remote state"""

--- a/src/databricks/labs/blueprint/parallel.py
+++ b/src/databricks/labs/blueprint/parallel.py
@@ -53,7 +53,9 @@ class Threads(Generic[Result]):
     @classmethod
     def strict(cls, name: str, tasks: Sequence[Task[Result]]) -> Collection[Result]:
         """Run tasks in parallel and raise ManyError if any task fails"""
-        __tracebackhide__ = True
+        # this dunder variable is hiding this method from tracebacks, making it cleaner
+        # for the user to see the actual error without too much noise.
+        __tracebackhide__ = True  # pylint: disable=unused-variable
         collected, errs = cls.gather(name, tasks)
         if errs:
             if len(errs) == 1:

--- a/src/databricks/labs/blueprint/parallel.py
+++ b/src/databricks/labs/blueprint/parallel.py
@@ -53,8 +53,11 @@ class Threads(Generic[Result]):
     @classmethod
     def strict(cls, name: str, tasks: Sequence[Task[Result]]) -> Collection[Result]:
         """Run tasks in parallel and raise ManyError if any task fails"""
+        __tracebackhide__ = True
         collected, errs = cls.gather(name, tasks)
         if errs:
+            if len(errs) == 1:
+                raise errs[0]
             raise ManyError(errs)
         return collected
 


### PR DESCRIPTION
…