### PR TITLE
handle functools.partial parameters in error messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "mypy",
     "types-PyYAML",
     "types-requests",
+    "black"
 ]
 
 python="3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ dependencies = [
     "isort>=2.5.0",
     "mypy",
     "types-PyYAML",
-    "types-requests",
-    "black"
+    "types-requests"
 ]
 
 python="3.10"

--- a/src/databricks/labs/blueprint/parallel.py
+++ b/src/databricks/labs/blueprint/parallel.py
@@ -9,7 +9,6 @@ import re
 import threading
 from collections.abc import Callable, Collection, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from functools import partial
 from typing import Generic, TypeVar
 
 MIN_THREADS = 8
@@ -138,7 +137,7 @@ class Threads(Generic[Result]):
         @functools.wraps(func)
         def inner(*args, **kwargs):
             def _get_signature(f):
-                if isinstance(f, partial):
+                if isinstance(f, functools.partial):
                     try:
                         args = []
                         args.extend(repr(x) for x in f.args)

--- a/src/databricks/labs/blueprint/parallel.py
+++ b/src/databricks/labs/blueprint/parallel.py
@@ -131,30 +131,33 @@ class Threads(Generic[Result]):
                 logger.info(msg)
 
     @staticmethod
+    def _get_result_function_signature(func, name):
+        if isinstance(func, functools.partial):
+            # try to build up signature, this should never fail
+            try:
+                args = []
+                args.extend(repr(x) for x in func.args)
+                args.extend(f"{k}={v!r}" for (k, v) in func.keywords.items())
+                args_str = ", ".join(args)
+                if args_str:
+                    return f"{name}({args_str})"
+                return name
+            # but if it would ever fail, better return generic serialized name, than messing up traceback even more...
+            except Exception:  # pylint: disable=broad-exception-caught
+                return str(func)
+
+        return name
+
+    @staticmethod
     def _wrap_result(func, name):
         """This method emulates GoLang's error return style"""
 
         @functools.wraps(func)
         def inner(*args, **kwargs):
-            def _get_signature(f):
-                if isinstance(f, functools.partial):
-                    try:
-                        args = []
-                        args.extend(repr(x) for x in f.args)
-                        args.extend(f"{k}={v!r}" for (k, v) in f.keywords.items())
-                        args_str = ", ".join(args)
-                        if args_str:
-                            return f"{name}({args_str})"
-                        return name
-                    except Exception:  # pylint: disable=broad-exception-caught
-                        return str(f)
-
-                return name
-
             try:
                 return func(*args, **kwargs), None
             except Exception as err:  # pylint: disable=broad-exception-caught
-                signature = _get_signature(func)
+                signature = Threads._get_result_function_signature(func, name)
                 logger.error(f"{signature} task failed: {err!s}", exc_info=err)
                 return None, err
 

--- a/tests/unit/test_parallel.py
+++ b/tests/unit/test_parallel.py
@@ -137,6 +137,11 @@ def test_odd_partial_failed(caplog):
         partial(fails_on_odd),
         partial(fails_on_odd, n="aaa"),
     ]
+
+    signatures = [Threads._get_result_function_signature(func, "test") for func in tasks]
+
+    assert signatures == ["test(n=1)", "test(1, dummy='6')", "test", "test(n='aaa')"]
+
     results, errors = Threads.gather("testing", tasks)
 
     assert [] == results

--- a/tests/unit/test_parallel.py
+++ b/tests/unit/test_parallel.py
@@ -138,10 +138,6 @@ def test_odd_partial_failed(caplog):
         partial(fails_on_odd, n="aaa"),
     ]
 
-    signatures = [Threads._get_result_function_signature(func, "test") for func in tasks]
-
-    assert signatures == ["test(n=1)", "test(1, dummy='6')", "test", "test(n='aaa')"]
-
     results, errors = Threads.gather("testing", tasks)
 
     assert [] == results


### PR DESCRIPTION
When partial methods are used, the error messages don't give any information which function invocation cased a problem.

This PR resolves it by adding optional info (args and/or kwargs) in the error message. Existing non-partial function error messages are not changed in any way.

`black` dependency was added, otherwise `make lint` was erroring out for me. (`make dev` did not pull it in for some reason)

I have ran `make fmt`, `make lint`, `make test`. All green!

