### PR TITLE
Added upstream wheel uploads for Databricks Workspaces without Public Internet access

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,11 +933,11 @@ This will print something like:
 
 You can also do `wheels.upload_to_dbfs()`, though you're not able to set any access control over it.
 
-### Publishing the dependencies of the wheel to Databricks Workspace
+### Publishing upstream dependencies to Databricks Workspace without Public Internet access
 
-When you build a wheel, it may have dependencies that are not included in the wheel itself. These dependencies are usually other Python packages that your wheel relies on. To ensure that your wheel works correctly when it is installed, these dependencies also need to be available in the same environment.
+Python wheel may have dependencies that are not included in the wheel itself. These dependencies are usually other Python packages that your wheel relies on. During installation on regular Databricks Workspaces, these dependencies get automatically fetched from [Python Package Index](https://pypi.org/). 
 
-While in many instances, the required packages are readily available in Databricks Runtime (DBR) or PyPi, there may be situations where specific dependencies need to be manually uploaded to the Databricks Workspace. This ensures that all necessary packages are present, allowing your wheel to operate correctly in its intended environment.
+Some Databricks Workspaces are configured with extra layers of network security, that block all access to Public Internet, including [Python Package Index](https://pypi.org/). To ensure installations working on these kinds of workspaces, developers need to explicitly upload all upstream dependencies for their applications to work correctly.
 
 The `upload_wheel_dependencies(prefixes)` method can be used to upload these dependencies to Databricks Workspace. This method takes a list of prefixes as an argument. It will upload all the dependencies of the wheel that have names starting with any of the provided prefixes.
 

--- a/README.md
+++ b/README.md
@@ -933,6 +933,33 @@ This will print something like:
 
 You can also do `wheels.upload_to_dbfs()`, though you're not able to set any access control over it.
 
+### Publishing the dependencies of the wheel to Databricks Workspace
+
+When you build a wheel, it may have dependencies that are not included in the wheel itself. These dependencies are usually other Python packages that your wheel relies on. To ensure that your wheel works correctly when it is installed, these dependencies also need to be available in the same environment.
+
+While in many instances, the required packages are readily available in Databricks Runtime (DBR) or PyPi, there may be situations where specific dependencies need to be manually uploaded to the Databricks Workspace. This ensures that all necessary packages are present, allowing your wheel to operate correctly in its intended environment.
+
+The `upload_wheel_dependencies(prefixes)` method can be used to upload these dependencies to Databricks Workspace. This method takes a list of prefixes as an argument. It will upload all the dependencies of the wheel that have names starting with any of the provided prefixes.
+
+Here is an example of how you can use this method:
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.labs.blueprint.wheels import ProductInfo
+
+ws = WorkspaceClient()
+product_info = ProductInfo(__file__)
+installation = product_info.current_installation(ws)
+
+with product_info.wheels(ws) as wheels:
+    wheel_paths = wheels.upload_wheel_dependencies(['databricks_sdk', 'pandas'])
+    for path in wheel_paths:
+        print(f'Uploaded dependency to {path}')
+```
+
+In this example, the `upload_wheel_dependencies(['databricks_sdk', 'pandas'])` call will upload all the dependencies of the wheel that have names starting with 'databricks_sdk' or 'pandas'. This method excludes any platform specific dependencies (i.e. ending with `-none-any.whl`). Also the main wheel file is not uploaded. The method returns a list of paths to the uploaded dependencies on WorkspaceFS.
+
+
 [[back to top](#databricks-labs-blueprint)]
 
 ## Databricks CLI's `databricks labs ...` Router

--- a/src/databricks/labs/blueprint/wheels.py
+++ b/src/databricks/labs/blueprint/wheels.py
@@ -237,9 +237,7 @@ class WheelsV2(AbstractContextManager):
         :param prefixes : A list of prefixes to match against the wheel names. If a prefix matches, the wheel is uploaded.
         """
         remote_paths = []
-        for wheel in list(
-            self._build_wheel(self._tmp_dir.name, verbose=self._verbose, no_deps=False, dirs_exist_ok=True)
-        ):
+        for wheel in self._build_wheel(self._tmp_dir.name, verbose=self._verbose, no_deps=False, dirs_exist_ok=True):
             if not wheel.name.endswith("-none-any.whl"):
                 continue
             # main wheel is uploaded with upload_to_wsfs() method.
@@ -288,11 +286,9 @@ class WheelsV2(AbstractContextManager):
             # and override the version file
             self._override_version_to_unreleased(checkout_root)
         args = [sys.executable, "-m", "pip", "wheel", "--wheel-dir", tmp_dir, checkout_root.as_posix()]
+        logger.debug(f"Building wheel for {checkout_root} in {tmp_dir}")
         if no_deps:
-            logger.debug(f"Building wheel for {checkout_root} in {tmp_dir}")
             args.append("--no-deps")
-        else:
-            logger.debug(f"Building dependencies for {checkout_root} in {tmp_dir}")
         subprocess.run(
             args,
             check=True,

--- a/src/databricks/labs/blueprint/wheels.py
+++ b/src/databricks/labs/blueprint/wheels.py
@@ -215,31 +215,61 @@ class WheelsV2(AbstractContextManager):
 
     __version: str | None = None
 
-    def __init__(self, installation: Installation, product_info: ProductInfo, *, verbose: bool = False):
+    def __init__(
+        self, installation: Installation, product_info: ProductInfo, *, verbose: bool = False, no_deps: bool = True
+    ):
         self._installation = installation
         self._product_info = product_info
         self._verbose = verbose
+        self._no_deps = no_deps
 
-    def upload_to_dbfs(self, force_dependencies: bool = False) -> str:
+    def upload_to_dbfs(self) -> str:
         """Uploads the wheel to DBFS location of installation and returns the remote path."""
+        main_wheel = []
         for wheel in self._local_wheel:
-            if force_dependencies or self._product_info.product_name() in wheel.name:
-                with wheel.open("rb") as f:
-                    remote_wheel = self._installation.upload_dbfs(f"wheels/{wheel.name}", f)
-                    if self._product_info.product_name() in wheel.name:
-                        main_wheel_remote_path = remote_wheel
-        return main_wheel_remote_path
+            if self._product_info.product_name() in wheel.name:
+                main_wheel.append(wheel)
+        if len(main_wheel) == 1:
+            with main_wheel[0].open("rb") as f:
+                return self._installation.upload_dbfs(f"wheels/{main_wheel[0].name}", f)
+        raise ValueError(
+            f"Expected one wheel containing product name {self._product_info.product_name()}, got {main_wheel}"
+        )
 
-    def upload_to_wsfs(self, force_dependencies: bool = False) -> str:
+    def upload_to_wsfs(self) -> str:
         """Uploads the wheel to WSFS location of installation and returns the remote path."""
+        # TODO: This function should be modified as there is no guarantee that the main wheel.name contains product name in it - anyway the input is a list of wheels
+        main_wheel = []
         for wheel in self._local_wheel:
-            if force_dependencies or self._product_info.product_name() in wheel.name:
-                with wheel.open("rb") as f:
-                    remote_wheel = self._installation.upload(f"wheels/{wheel.name}", f.read())
-                    if self._product_info.product_name() in wheel.name:
-                        self._installation.save(Version(self._product_info.version(), remote_wheel, self._now_iso()))
-                        main_wheel_remote_path = remote_wheel
-        return main_wheel_remote_path
+            if self._product_info.product_name() in wheel.name:
+                main_wheel.append(wheel)
+        if len(main_wheel) == 1:
+            remote_wheel = self._installation.upload(f"wheels/{main_wheel[0].name}", main_wheel[0].read_bytes())
+            self._installation.save(Version(self._product_info.version(), remote_wheel, self._now_iso()))
+            return remote_wheel
+        raise ValueError(
+            f"Expected one wheel containing product name {self._product_info.product_name()}, got {main_wheel}"
+        )
+
+    def upload_upstream_dependencies_to_wsfs(self, prefixes: list[str] | None = None) -> list[str]:
+        """Uploads the wheel dependencies to WSFS location of installation and returns the remote paths.
+        :param prefixes (optional): A list of prefixes to match against the wheel names. If a prefix matches, the wheel is uploaded. If None, all wheels are uploaded. Defaults to None.
+        """
+        if prefixes is None:
+            prefixes = [wheel.name for wheel in self._local_wheel]
+        remote_paths = []
+        for wheel in self._local_wheel:
+            for prefix in prefixes:
+                # TODO: This function should be modified as there is no guarantee that the main wheel.name contains product name in it
+                # TODO: In the future the need of passing explicit prefixes should be removed
+                if (
+                    prefix in wheel.name
+                    and wheel.name.endswith("-none-any.whl")
+                    and self._product_info.product_name() not in wheel.name
+                ):
+                    remote_wheel = self._installation.upload(f"wheels/{wheel.name}", wheel.read_bytes())
+                    remote_paths.append(remote_wheel)
+        return remote_paths
 
     @staticmethod
     def _now_iso():
@@ -249,20 +279,20 @@ class WheelsV2(AbstractContextManager):
     def __enter__(self) -> "WheelsV2":
         """Builds the wheel and returns the instance. Use it as a context manager."""
         self._tmp_dir = tempfile.TemporaryDirectory()
-        self._local_wheel = self._build_wheel(self._tmp_dir.name, verbose=self._verbose)
+        self._local_wheel = self._build_wheel(self._tmp_dir.name, verbose=self._verbose, no_deps=self._no_deps)
         return self
 
     def __exit__(self, __exc_type, __exc_value, __traceback):
         """Cleans up the temporary directory. Use it as a context manager."""
         self._tmp_dir.cleanup()
 
-    def _build_wheel(self, tmp_dir: str, *, verbose: bool = False):
+    def _build_wheel(self, tmp_dir: str, *, verbose: bool = False, no_deps: bool = True) -> list[Path]:
         """Helper to build the wheel package
 
         :param tmp_dir: str:
         :param *:
         :param verbose: bool:  (Default value = False)
-
+        :param no_deps: bool:  (Default value = True)
         """
         stdout = subprocess.STDOUT
         stderr = subprocess.STDOUT
@@ -275,14 +305,23 @@ class WheelsV2(AbstractContextManager):
             checkout_root = self._copy_root_to(tmp_dir)
             # and override the version file
             self._override_version_to_unreleased(checkout_root)
-        logger.debug(f"Building wheel for {checkout_root} in {tmp_dir}")
-        subprocess.run(
-            [sys.executable, "-m", "pip", "wheel", "--wheel-dir", tmp_dir, checkout_root.as_posix()],
-            check=True,
-            stdout=stdout,
-            stderr=stderr,
-        )
-        # get wheel name as first file in the temp directory
+        if no_deps:
+            logger.debug(f"Building wheel for {checkout_root} in {tmp_dir} without dependencies")
+            subprocess.run(
+                [sys.executable, "-m", "pip", "wheel", "--no-deps", "--wheel-dir", tmp_dir, checkout_root.as_posix()],
+                check=True,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        else:
+            logger.debug(f"Building wheel for {checkout_root} in {tmp_dir} with dependencies")
+            subprocess.run(
+                [sys.executable, "-m", "pip", "wheel", "--wheel-dir", tmp_dir, checkout_root.as_posix()],
+                check=True,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        # get all the wheel names in the temp directory
         return list(Path(tmp_dir).glob("*.whl"))
 
     def _override_version_to_unreleased(self, tmp_dir_path: Path):

--- a/tests/integration/test_wheels.py
+++ b/tests/integration/test_wheels.py
@@ -17,3 +17,6 @@ def test_upload_dbfs(ws, new_installation):
     with WheelsV2(new_installation, product_info) as whl:
         remote_wheel = whl.upload_to_dbfs()
         ws.dbfs.get_status(remote_wheel)
+
+
+# TODO: to add an integration test for upload_wheel_dependencies (currently getting an access issue to the test environment)

--- a/tests/unit/test_wheels.py
+++ b/tests/unit/test_wheels.py
@@ -38,6 +38,16 @@ def test_build_and_upload_wheel():
         installation.assert_file_dbfs_uploaded(re.compile("wheels/databricks_labs_blueprint-*"))
     assert not os.path.exists(wheels._local_wheel)
 
+def test_build_and_dependencies_upload_wheel():
+    installation = MockInstallation()
+    product_info = ProductInfo.from_class(MockInstallation)
+
+    wheels = WheelsV2(installation, product_info)
+    with wheels:
+        wheel_paths = wheels.upload_wheel_dependencies(["databricks_sdk"])
+        assert len(wheel_paths) == 1
+        installation.assert_file_uploaded(re.compile("wheels/databricks_sdk-*"))
+
 
 def test_unreleased_version(tmp_path):
     if not is_in_debug():

--- a/tests/unit/test_wheels.py
+++ b/tests/unit/test_wheels.py
@@ -38,6 +38,7 @@ def test_build_and_upload_wheel():
         installation.assert_file_dbfs_uploaded(re.compile("wheels/databricks_labs_blueprint-*"))
     assert not os.path.exists(wheels._local_wheel)
 
+
 def test_build_and_dependencies_upload_wheel():
     installation = MockInstallation()
     product_info = ProductInfo.from_class(MockInstallation)

--- a/tests/unit/test_wheels.py
+++ b/tests/unit/test_wheels.py
@@ -15,13 +15,13 @@ from databricks.labs.blueprint.wheels import (
 )
 
 
-def test_build_and_upload_wheel():  # TODO: modify this test to consider different scenarios  (change to this test is inevitable if we go ahead with  _build_wheel -> list[Path])
+def test_build_and_upload_wheel():
     installation = MockInstallation()
     product_info = ProductInfo.from_class(MockInstallation)
 
     wheels = WheelsV2(installation, product_info)
     with wheels:
-        assert os.path.exists(wheels._local_wheel[0])
+        assert os.path.exists(wheels._local_wheel)
 
         remote_on_wsfs = wheels.upload_to_wsfs()
         installation.assert_file_uploaded(re.compile("wheels/databricks_labs_blueprint-*"))
@@ -36,7 +36,7 @@ def test_build_and_upload_wheel():  # TODO: modify this test to consider differe
 
         wheels.upload_to_dbfs()
         installation.assert_file_dbfs_uploaded(re.compile("wheels/databricks_labs_blueprint-*"))
-    assert not os.path.exists(wheels._local_wheel[0])
+    assert not os.path.exists(wheels._local_wheel)
 
 
 def test_unreleased_version(tmp_path):

--- a/tests/unit/test_wheels.py
+++ b/tests/unit/test_wheels.py
@@ -15,16 +15,15 @@ from databricks.labs.blueprint.wheels import (
 )
 
 
-def test_build_and_upload_wheel():
+def test_build_and_upload_wheel():  # TODO: modify this test to consider different scenarios  (change to this test is inevitable if we go ahead with  _build_wheel -> list[Path])
     installation = MockInstallation()
     product_info = ProductInfo.from_class(MockInstallation)
 
     wheels = WheelsV2(installation, product_info)
     with wheels:
-        for wheel in wheels._local_wheel:
-            assert os.path.exists(wheel)
+        assert os.path.exists(wheels._local_wheel[0])
 
-        remote_on_wsfs = wheels.upload_to_wsfs(force_dependencies=False)
+        remote_on_wsfs = wheels.upload_to_wsfs()
         installation.assert_file_uploaded(re.compile("wheels/databricks_labs_blueprint-*"))
         installation.assert_file_written(
             "version.json",
@@ -35,31 +34,9 @@ def test_build_and_upload_wheel():
             },
         )
 
-        wheels.upload_to_dbfs(force_dependencies=False)
+        wheels.upload_to_dbfs()
         installation.assert_file_dbfs_uploaded(re.compile("wheels/databricks_labs_blueprint-*"))
-    for wheel in wheels._local_wheel:
-        assert not os.path.exists(wheel)
-
-
-def test_build_and_upload_wheel_with_no_dependency():
-    installation = MockInstallation()
-    product_info = ProductInfo.from_class(MockInstallation)
-
-    wheels = WheelsV2(installation, product_info)
-    with wheels:
-        remote_on_wsfs = wheels.upload_to_wsfs(force_dependencies=True)
-        installation.assert_file_uploaded(re.compile("wheels/databricks_labs_blueprint-*"))
-        installation.assert_file_written(
-            "version.json",
-            {
-                "version": product_info.version(),
-                "wheel": remote_on_wsfs,
-                "date": ...,
-            },
-        )
-
-        wheels.upload_to_dbfs(force_dependencies=True)
-        installation.assert_file_dbfs_uploaded(re.compile("wheels/databricks_labs_blueprint-*"))
+    assert not os.path.exists(wheels._local_wheel[0])
 
 
 def test_unreleased_version(tmp_path):


### PR DESCRIPTION
The output of the build wheel function will be a list of all the dependent wheel packages. Upload functions will get a new flag as input to either include the dependencies in the download list or just limit the download to the main wheel package.

Relates to https://github.com/databrickslabs/ucx/issues/573