### PR TITLE
added content assertion for `assert_file_uploaded` and `assert_file_dbfs_uploaded` in `MockInstallation`

### DIFF
--- a/src/databricks/labs/blueprint/installation.py
+++ b/src/databricks/labs/blueprint/installation.py
@@ -903,11 +903,11 @@ class MockInstallation(Installation):
         actual = self._overwrites[filename]
         assert expected == actual, f"{filename} content missmatch"
 
-    def assert_file_uploaded(self, filename, expected: bytes):
+    def assert_file_uploaded(self, filename, expected: bytes | None = None):
         """Asserts that a file was uploaded with the expected content"""
         self._assert_upload(filename, self._uploads, expected)
 
-    def assert_file_dbfs_uploaded(self, filename, expected: bytes):
+    def assert_file_dbfs_uploaded(self, filename, expected: bytes | None = None):
         """Asserts that a file was uploaded to DBFS with the expected content"""
         self._assert_upload(filename, self._dbfs, expected)
 
@@ -915,12 +915,14 @@ class MockInstallation(Installation):
         assert self._removed
 
     @staticmethod
-    def _assert_upload(filename: Any, loc: dict[str, bytes], expected: bytes):
+    def _assert_upload(filename: Any, loc: dict[str, bytes], expected: bytes | None = None):
         if isinstance(filename, re.Pattern):
             for name in loc.keys():
                 if filename.match(name):
-                    assert loc[name] == expected, f"{filename} content missmatch"
+                    if expected:
+                        assert loc[name] == expected, f"{filename} content missmatch"
                     return
             raise AssertionError(f'Cannot find {filename.pattern} among {", ".join(loc.keys())}')
         assert filename in loc, f"{filename} had no writes"
-        assert loc[filename] == expected, f"{filename} content missmatch"
+        if expected:
+            assert loc[filename] == expected, f"{filename} content missmatch"

--- a/src/databricks/labs/blueprint/installation.py
+++ b/src/databricks/labs/blueprint/installation.py
@@ -918,10 +918,11 @@ class MockInstallation(Installation):
     def _assert_upload(filename: Any, loc: dict[str, bytes], expected: bytes | None = None):
         if isinstance(filename, re.Pattern):
             for name in loc.keys():
-                if filename.match(name):
-                    if expected:
-                        assert loc[name] == expected, f"{filename} content missmatch"
-                    return
+                if not filename.match(name):
+                    continue
+                if expected:
+                    assert loc[name] == expected, f"{filename} content missmatch"
+                return
             raise AssertionError(f'Cannot find {filename.pattern} among {", ".join(loc.keys())}')
         assert filename in loc, f"{filename} had no writes"
         if expected:

--- a/src/databricks/labs/blueprint/installation.py
+++ b/src/databricks/labs/blueprint/installation.py
@@ -903,20 +903,24 @@ class MockInstallation(Installation):
         actual = self._overwrites[filename]
         assert expected == actual, f"{filename} content missmatch"
 
-    def assert_file_uploaded(self, filename):
-        self._assert_upload(filename, self._uploads)
+    def assert_file_uploaded(self, filename, expected: bytes):
+        """Asserts that a file was uploaded with the expected content"""
+        self._assert_upload(filename, self._uploads, expected)
 
-    def assert_file_dbfs_uploaded(self, filename):
-        self._assert_upload(filename, self._dbfs)
+    def assert_file_dbfs_uploaded(self, filename, expected: bytes):
+        """Asserts that a file was uploaded to DBFS with the expected content"""
+        self._assert_upload(filename, self._dbfs, expected)
 
     def assert_removed(self):
         assert self._removed
 
     @staticmethod
-    def _assert_upload(filename: Any, loc: dict[str, bytes]):
+    def _assert_upload(filename: Any, loc: dict[str, bytes], expected: bytes):
         if isinstance(filename, re.Pattern):
             for name in loc.keys():
                 if filename.match(name):
+                    assert loc[name] == expected, f"{filename} content missmatch"
                     return
             raise AssertionError(f'Cannot find {filename.pattern} among {", ".join(loc.keys())}')
         assert filename in loc, f"{filename} had no writes"
+        assert loc[filename] == expected, f"{filename} content missmatch"

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -445,3 +445,9 @@ def test_load_empty_data_class():
     )
     load = installation.load(ComplexClass, filename="backups/complex-class.json")
     assert load == complex_class
+
+
+def test_assert_file_uploaded():
+    installation = MockInstallation()
+    installation.upload("foo", b"bar")
+    installation.assert_file_uploaded("foo", b"bar")


### PR DESCRIPTION
Add `expected: bytes` parameter to assert that the content uploaded to MockInstallation is correct