### PR TITLE
Fixed test failures 

### DIFF
--- a/src/databricks/labs/blueprint/upgrades.py
+++ b/src/databricks/labs/blueprint/upgrades.py
@@ -78,7 +78,7 @@ class Upgrades:
             logger.warning(f"No upgrades folder: {upgrades_folder}")
             return
         applied = self._installation.load_or_default(AppliedUpgrades)
-        for script in self._diff(upgrades_folder):
+        for script in sorted(self._diff(upgrades_folder)):
             if script.name in applied.upgrades:
                 logger.info(f"Already applied: {script.name}")
                 continue

--- a/src/databricks/labs/blueprint/wheels.py
+++ b/src/databricks/labs/blueprint/wheels.py
@@ -334,7 +334,12 @@ class Wheels(WheelsV2):
     """Wheel builder"""
 
     def __init__(
-        self, ws: WorkspaceClient, install_state: InstallState, product_info: ProductInfo, *, verbose: bool = False
+        self,
+        ws: WorkspaceClient,
+        install_state: InstallState,
+        product_info: ProductInfo,
+        *,
+        verbose: bool = False,
     ):
         warnings.warn("Wheels is deprecated, use WheelsV2 instead", DeprecationWarning)
         installation = Installation(ws, product_info.product_name(), install_folder=install_state.install_folder())

--- a/src/databricks/labs/blueprint/wheels.py
+++ b/src/databricks/labs/blueprint/wheels.py
@@ -75,7 +75,7 @@ class ProductInfo:
         return self._version_file
 
     @cached_property
-    def __version__(self):
+    def _version(self):
         """Returns current version of the project"""
         if not self.is_git_checkout():
             # normal install, downloaded releases won't have the .git folder
@@ -83,7 +83,7 @@ class ProductInfo:
         return self.unreleased_version()
 
     def version(self):
-        return self.__version__
+        return self._version
 
     def as_semver(self) -> SemVer:
         """Returns the version as SemVer object."""
@@ -334,7 +334,7 @@ class Wheels(WheelsV2):
     """Wheel builder"""
 
     def __init__(
-            self, ws: WorkspaceClient, install_state: InstallState, product_info: ProductInfo, *, verbose: bool = False
+        self, ws: WorkspaceClient, install_state: InstallState, product_info: ProductInfo, *, verbose: bool = False
     ):
         warnings.warn("Wheels is deprecated, use WheelsV2 instead", DeprecationWarning)
         installation = Installation(ws, product_info.product_name(), install_folder=install_state.install_folder())

--- a/src/databricks/labs/blueprint/wheels.py
+++ b/src/databricks/labs/blueprint/wheels.py
@@ -74,16 +74,16 @@ class ProductInfo:
         See https://packaging.python.org/guides/single-sourcing-package-version/"""
         return self._version_file
 
-    def version(self):
+    @cached_property
+    def __version__(self):
         """Returns current version of the project"""
-        if hasattr(self, "__version"):
-            return self.__version  # pylint: disable=access-member-before-definition
         if not self.is_git_checkout():
             # normal install, downloaded releases won't have the .git folder
-            self.__version = self.released_version()
-            return self.__version
-        self.__version = self.unreleased_version()
-        return self.__version
+            return self.released_version()
+        return self.unreleased_version()
+
+    def version(self):
+        return self.__version__
 
     def as_semver(self) -> SemVer:
         """Returns the version as SemVer object."""
@@ -334,7 +334,7 @@ class Wheels(WheelsV2):
     """Wheel builder"""
 
     def __init__(
-        self, ws: WorkspaceClient, install_state: InstallState, product_info: ProductInfo, *, verbose: bool = False
+            self, ws: WorkspaceClient, install_state: InstallState, product_info: ProductInfo, *, verbose: bool = False
     ):
         warnings.warn("Wheels is deprecated, use WheelsV2 instead", DeprecationWarning)
         installation = Installation(ws, product_info.product_name(), install_folder=install_state.install_folder())


### PR DESCRIPTION
Nightly is failing due to #103
- Made `ProductInfo.version` a `cached_property`, to avoid failure when comparing wheel uploads in development
- Sorted upgrade scripts to ensure they are applied in semver order