### PR TITLE
Apply type casting & remove empty kwarg for Command

### DIFF
--- a/src/databricks/labs/blueprint/cli.py
+++ b/src/databricks/labs/blueprint/cli.py
@@ -36,9 +36,11 @@ class Command:
                 return param.name
         return None
 
-    def get_argument_type(self, argument_name: str) -> type:
+    def get_argument_type(self, argument_name: str) -> str | None:
         sig = inspect.signature(self.fn)
-        return sig.parameters[argument_name].annotation
+        if argument_name not in sig.parameters:
+            return None
+        return sig.parameters[argument_name].annotation.__name__
 
 
 class App:
@@ -85,7 +87,7 @@ class App:
         cmd = self._mapping[command]
         # modify kwargs to match the type of the argument
         for kwarg in list(kwargs.keys()):
-            match cmd.get_argument_type(kwarg).__name__:
+            match cmd.get_argument_type(kwarg):
                 case "int":
                     kwargs[kwarg] = int(kwargs[kwarg])
                 case "bool":

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -41,12 +41,12 @@ def test_injects_prompts():
     app = App(inspect.getfile(App))
 
     @app.command(is_unauthenticated=True)
-    def foo(name: str, prompts: Prompts):
+    def foo(name: str, age: int, salary: float, is_customer: bool, prompts: Prompts, address: str = "default"):
         """Some comment"""
         assert isinstance(prompts, Prompts)
-        some(name)
+        some(name, age, salary, is_customer, address)
 
     with mock.patch.object(sys, "argv", [..., FOO_COMMAND]):
         app()
 
-    some.assert_called_with("y")
+    some.assert_called_with("y", 100, 100.5, True, "default")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,6 +11,10 @@ FOO_COMMAND = json.dumps(
         "command": "foo",
         "flags": {
             "name": "y",
+            "age": "100",
+            "salary": "100.5",
+            "address": "",
+            "is_customer": "true",
             "log_level": "disabled",
         },
     }
@@ -22,14 +26,14 @@ def test_commands():
     app = App(inspect.getfile(App))
 
     @app.command(is_unauthenticated=True)
-    def foo(name: str):
+    def foo(name: str, age: int, salary: float, is_customer: bool, address: str = "default"):
         """Some comment"""
-        some(name)
+        some(name, age, salary, is_customer, address)
 
     with mock.patch.object(sys, "argv", [..., FOO_COMMAND]):
         app()
 
-    some.assert_called_with("y")
+    some.assert_called_with("y", 100, 100.5, True, "default")
 
 
 def test_injects_prompts():


### PR DESCRIPTION
Currently, all kwargs are passed into `App.command` as `str`. Empty kwarg is passed as empty string.

In this PR, we remove any empty kwarg, and apply casting based on the kwarg annotation for primitive types