### PR TITLE
Added Collection functionality to run cli cmd as collection

### DIFF
--- a/src/databricks/labs/blueprint/cli.py
+++ b/src/databricks/labs/blueprint/cli.py
@@ -32,6 +32,11 @@ class Command:
         return True
 
     def run_as_collection(self) -> bool:
+        # A Method can be run as standalone workspace cmd or as a collection. To mark a method as collection method
+        # we need to add is_collection flag to True
+        # In addition if the collection_workspace_id is passed then return True else return False
+        # if collection_workspace_id is passed, the cmd should be run under account client else
+        # as workspace client.
         if not self.is_collection:
             return False
         sig = inspect.signature(self.fn)
@@ -111,8 +116,12 @@ class App:
                     kwargs[kwarg] = float(kwargs[kwarg])
         try:
             if cmd.needs_workspace_client() and not cmd.run_as_collection():
+                # if is_account is not set and cmd is either not a collection or
+                # is a collection but collection_workspace_id not passed
                 kwargs["w"] = self._workspace_client()
             elif cmd.is_account or cmd.run_as_collection():
+                # if is_account is  set or cmd is a collection
+                # and collection_workspace_id is passed
                 kwargs["a"] = self._account_client()
             prompts_argument = cmd.prompts_argument_name()
             if prompts_argument:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -105,13 +105,13 @@ def test_collection_commands_workspace(mocker):
 
     @app.command(is_unauthenticated=False, is_collection=True)
     def foo(
-            name: str,
-            age: int,
-            salary: float,
-            is_customer: bool,
-            w: WorkspaceClient,
-            address: str = "default",
-            optional_arg: str | None = None,
+        name: str,
+        age: int,
+        salary: float,
+        is_customer: bool,
+        w: WorkspaceClient,
+        address: str = "default",
+        optional_arg: str | None = None,
     ):
         """Some comment"""
         some(name, age, salary, is_customer, address, optional_arg, w)


### PR DESCRIPTION
This change introduces the concept of collection in cli commands.

Background:
A cli cmd can be run as a current workspace installation command or as a collection.
When it is run as a collection, an Account client is created which can be used to run the cmd for all workspaces of a collection
When it is run as a non collection, a workspace client is created

Changes:
 - added is_collection bool to identify a cli cmd as eligible to run as collection
 - checking if collection_workspace_id is passed, if yes create a Account Client else create Workspace Client