### PR TITLE
Fixed `WorkspacePath` support for python 3.11

### DIFF
--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -423,15 +423,14 @@ class WorkspacePath(Path):
 
     def expanduser(self):
         # Expand ~ (but NOT ~user) constructs.
-        if not (self._drv or self._root) and self._parts:
-            match self._parts:
-                case ["~"]:
-                    user_name = self._ws.current_user.me().user_name
-                case ["~", *other_user]:
-                    msg = f"Cannot determine home directory for: {other_user}"
-                    raise RuntimeError(msg)
-                case _:
-                    return self
+        if (not (self._drv or self._root) and
+                self._parts and self._parts[0][:1] == "~"):
+            if self._parts[0] == "~":
+                user_name = self._ws.current_user.me().user_name
+            else:
+                other_user = self._parts[0][1:]
+                msg = f"Cannot determine home directory for: {other_user}"
+                raise RuntimeError(msg)
             if user_name is None:
                 raise RuntimeError("Could not determine home directory.")
             homedir = f"/Users/{user_name}"

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -124,10 +124,12 @@ class _ScandirItem:
     def __fspath__(self):
         return self._object_info.path
 
-    def is_dir(self):
+    def is_dir(self, follow_symlinks=False):  # pylint: disable=unused-argument
+        # follow_symlinks is for compatibility with Python 3.11
         return self._object_info.object_type == ObjectType.DIRECTORY
 
-    def is_file(self):
+    def is_file(self, follow_symlinks=False):  # pylint: disable=unused-argument
+        # follow_symlinks is for compatibility with Python 3.11
         # TODO: check if we want to show notebooks as files
         return self._object_info.object_type == ObjectType.FILE
 

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -423,8 +423,7 @@ class WorkspacePath(Path):
 
     def expanduser(self):
         # Expand ~ (but NOT ~user) constructs.
-        if (not (self._drv or self._root) and
-                self._parts and self._parts[0][:1] == "~"):
+        if not (self._drv or self._root) and self._parts and self._parts[0][:1] == "~":
             if self._parts[0] == "~":
                 user_name = self._ws.current_user.me().user_name
             else:

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -416,6 +416,11 @@ class WorkspacePath(Path):
         except DatabricksError:
             return False
 
+    def _scandir(self):
+        # Python 3.10: Accesses _accessor.scandir() directly.
+        # Python 3.11: Instead invokes this (which normally dispatches to os.scandir())
+        return self._accessor.scandir(self)
+
     def expanduser(self):
         # Expand ~ (but NOT ~user) constructs.
         if not (self._drv or self._root) and self._parts:


### PR DESCRIPTION
This PR fixes some issues with the `WorkspacePath` implementation so that it also works with 3.11. Due to internal changes between 3.10 and 3.11 fixes were needed for:

 - [X] `.expanduser()`
 - [x] `.glob()`

This will resolve #119.

Out of scope for this PR:

 - Any other bugs not currently being surfaced by the existing unit and integration tests.
 - Support for Python 3.12