### PR TITLE
Fix `.as_uri()` and `.absolute()` implementations for `WorkspacePath` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = ["databricks-sdk>=0.16.0"]

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -370,9 +370,7 @@ class WorkspacePath(Path):
     def __repr__(self):
         return f"{self.__class__.__name__}({str(self)!r})"
 
-    def as_uri(
-        self,
-    ) -> str:
+    def as_uri(self) -> str:
         return self._ws.config.host + "#workspace" + urlquote_from_bytes(bytes(self))
 
     def __eq__(self, other):

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -284,6 +284,7 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
     def __init__(self, ws: WorkspaceClient, *args) -> None:  # pylint: disable=super-init-not-called,useless-suppression
         # We deliberately do _not_ call the super initializer because we're taking over complete responsibility for the
         # implementation of the public API.
+
         # Convert the arguments into string-based path segments, irrespective of their type.
         raw_paths = self._to_raw_paths(*args)
 

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -346,10 +346,8 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
         # Based on the upstream implementation, with the '//'-specific bit elided because we don't need to
         # bother with Posix semantics.
         if part and part[0] == sep:
-            root, path = sep, part.lstrip(sep)
-        else:
-            root, path = "", part
-        return root, path
+            return sep, part.lstrip(sep)
+        return "", part
 
     def __reduce__(self) -> NoReturn:
         # Cannot support pickling because we can't pickle the workspace client.

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -357,6 +357,15 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
 
     def __fspath__(self):
         # Cannot support this: Workspace objects aren't accessible via the filesystem.
+        #
+        # This method is part of the os.PathLike protocol. Functions which accept a PathLike argument use os.fsname()
+        # to convert (via this method) the object into a file system path that can be used with the low-level os.*
+        # methods.
+        #
+        # Relevant online documentation:
+        #  - PEP 519 (https://peps.python.org/pep-0519/)
+        #  - os.fspath (https://docs.python.org/3/library/os.html#os.fspath)
+        # TODO: Allow this to work when within an appropriate Databricks Runtime that mounts Workspace paths via FUSE.
         msg = f"Workspace paths are not path-like: {self}"
         raise NotImplementedError(msg)
 

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -369,11 +369,6 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
             self._str = (self._root + self.parser.sep.join(self._path_parts)) or "."
             return self._str
 
-    def __bytes__(self):
-        # Super implementations are fine.
-        # TODO: Decide before PR merge whether to: a) remove; b) allow as marker that we checked it; c) inline to be independent.
-        return super().__bytes__()
-
     def __repr__(self):
         return f"{self.__class__.__name__}({str(self)!r})"
 
@@ -477,17 +472,6 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
                 pass
         return suffix
 
-    @property
-    def suffixes(self):
-        # Super implementations are all fine.
-        # TODO: Make this consistent with .suffix for notebooks.
-        return super().suffixes
-
-    @property
-    def stem(self):
-        # Super implementations are all fine.
-        return super().stem
-
     def with_name(self, name):
         parser = self.parser
         if not name or parser.sep in name or name == ".":
@@ -498,11 +482,6 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
             raise ValueError(f"{self!r} has an empty name")
         path_parts[-1] = name
         return type(self)(self._ws, self.anchor, *path_parts)
-
-    def with_stem(self, stem):  # pylint: disable=useless-parent-delegation
-        # Super implementations are all fine.
-        # TODO: Decide before PR merge whether to: a) remove; b) allow as marker that we checked it; c) inline to be independent.
-        return super().with_stem(stem)
 
     def with_suffix(self, suffix):
         stem = self.stem

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -704,6 +704,11 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
         """Return the absolute path of the file or directory in Databricks Workspace."""
         return self
 
+    def absolute(self):
+        if self.is_absolute():
+            return self
+        return self.with_segments(self.cwd(), self)
+
     def is_dir(self):
         """Return True if the path points to a directory in Databricks Workspace."""
         try:

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -213,7 +213,7 @@ class _TextUploadIO(_UploadIO, StringIO):  # type: ignore
         StringIO.__init__(self)
 
 
-class WorkspacePath(Path):
+class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
     """Experimental implementation of pathlib.Path for Databricks Workspace."""
 
     # Implementation notes:
@@ -235,7 +235,7 @@ class WorkspacePath(Path):
     #     3. Python 3.12 introduces some new API elements. Because these are source-compatible with earlier versions
     #        these are forward-ported and implemented.
     #
-    __slots__ = (
+    __slots__ = (  # pylint: disable=redefined-slots-in-subclass
         # For us this is always the empty string. Consistent with the superclass attribute for Python 3.10-3.13b.
         "_drv",
         # The (normalized) root property for the path. Consistent with the superclass attribute for Python 3.10-3.13b.
@@ -281,7 +281,9 @@ class WorkspacePath(Path):
         # Force all initialisation to go via __init__() irrespective of the (Python-specific) base version.
         return object.__new__(cls)
 
-    def __init__(self, ws: WorkspaceClient, *args) -> None:
+    def __init__(self, ws: WorkspaceClient, *args) -> None:  # pylint: disable=super-init-not-called,useless-suppression
+        # We deliberately do _not_ call the super initializer because we're taking over complete responsibility for the
+        # implementation of the public API.
         raw_paths: list[str] = []
         for arg in args:
             if isinstance(arg, PurePath):
@@ -499,10 +501,10 @@ class WorkspacePath(Path):
     def _stack(self):
         return self.anchor, list(reversed(self._path_parts))
 
-    def relative_to(self, other, *more_other, walk_up=False):
+    def relative_to(self, other, *more_other, walk_up=False):  # pylint: disable=arguments-differ
         other = self.with_segments(other, *more_other)
         anchor0, parts0 = self._stack
-        anchor1, parts1 = other._stack
+        anchor1, parts1 = other._stack  # pylint: disable=protected-access
         if anchor0 != anchor1:
             msg = f"{str(self)!r} and {str(other)!r} have different anchors"
             raise ValueError(msg)
@@ -518,12 +520,12 @@ class WorkspacePath(Path):
             parts0.append("..")
         return self.with_segments("", *reversed(parts0))
 
-    def is_relative_to(self, other, *more_other):
+    def is_relative_to(self, other, *more_other):  # pylint: disable=arguments-differ
         other = self.with_segments(other, *more_other)
         if self.anchor != other.anchor:
             return False
         parts0 = list(reversed(self._path_parts))
-        parts1 = list(reversed(other._path_parts))
+        parts1 = list(reversed(other._path_parts))  # pylint: disable=protected-access
         while parts0 and parts1 and parts0[-1] == parts1[-1]:
             parts0.pop()
             parts1.pop()

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -334,12 +334,11 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
                 path = part
             case [*parts]:
                 path = cls.parser.join(*parts)
-        if path:
-            root, rel = cls._splitroot(path, sep=cls.parser.sep)
-            # No need to split drv because we don't support it.
-            parsed = tuple(str(x) for x in rel.split(cls.parser.sep) if x and x != ".")
-        else:
-            root, parsed = "", ()
+        if not path:
+            return "", ()
+        root, rel = cls._splitroot(path, sep=cls.parser.sep)
+        # No need to split drv because we don't support it.
+        parsed = tuple(str(x) for x in rel.split(cls.parser.sep) if x and x != ".")
         return root, parsed
 
     @classmethod

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -232,7 +232,7 @@ class WorkspacePath(Path):
     # This implementation for Workspace paths does the following:
     #     1. Flavour is basically posix-style, with the caveat that we don't bother with the special //-prefix handling.
     #     2. The Accessor is delegated to existing routines available via the workspace client.
-    #     3. Python 3.12 introduces some new API elements. Because these are sourec-compatible with earlier versions
+    #     3. Python 3.12 introduces some new API elements. Because these are source-compatible with earlier versions
     #        these are forward-ported and implemented.
     #
     __slots__ = (

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -368,6 +368,7 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
 
     def __bytes__(self):
         # Super implementations are fine.
+        # TODO: Decide before PR merge whether to: a) remove; b) allow as marker that we checked it; c) inline to be independent.
         return super().__bytes__()
 
     def __repr__(self):
@@ -483,8 +484,9 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
         path_parts[-1] = name
         return type(self)(self._ws, self.anchor, *path_parts)
 
-    def with_stem(self, stem):
+    def with_stem(self, stem):  # pylint: disable=useless-parent-delegation
         # Super implementations are all fine.
+        # TODO: Decide before PR merge whether to: a) remove; b) allow as marker that we checked it; c) inline to be independent.
         return super().with_stem(stem)
 
     def with_suffix(self, suffix):

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import fnmatch
 import locale
@@ -244,7 +246,7 @@ class WorkspacePath(Path):
         return this.__from_raw_parts(this, ws, this._flavour, drv, root, parts)
 
     @staticmethod
-    def __from_raw_parts(this, ws: WorkspaceClient, flavour: _DatabricksFlavour, drv, root, parts) -> "WorkspacePath":
+    def __from_raw_parts(this, ws: WorkspaceClient, flavour: _DatabricksFlavour, drv, root, parts) -> WorkspacePath:
         # pylint: disable=protected-access
         this._accessor = _DatabricksAccessor(ws)
         this._flavour = flavour

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -365,7 +365,7 @@ class WorkspacePath(Path):
 
     def __bytes__(self):
         # Super implementations are fine.
-        return super(self).__bytes__()
+        return super().__bytes__()
 
     def __repr__(self):
         return f"{self.__class__.__name__}({str(self)!r})"

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -284,6 +284,19 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
     def __init__(self, ws: WorkspaceClient, *args) -> None:  # pylint: disable=super-init-not-called,useless-suppression
         # We deliberately do _not_ call the super initializer because we're taking over complete responsibility for the
         # implementation of the public API.
+        # Convert the arguments into string-based path segments, irrespective of their type.
+        raw_paths = self._to_raw_paths(*args)
+
+        # Normalise the paths that we have.
+        root, path_parts = self._parse_and_normalize(raw_paths)
+
+        self._drv = ""
+        self._root = root
+        self._path_parts = path_parts
+        self._ws = ws
+
+    @staticmethod
+    def _to_raw_paths(*args) -> list[str]:
         raw_paths: list[str] = []
         for arg in args:
             if isinstance(arg, PurePath):
@@ -300,14 +313,7 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
                     )
                     raise TypeError(msg)
                 raw_paths.append(path)
-
-        # Normalise the paths that we have.
-        root, path_parts = self._parse_and_normalize(raw_paths)
-
-        self._drv = ""
-        self._root = root
-        self._path_parts = path_parts
-        self._ws = ws
+        return raw_paths
 
     @classmethod
     def _parse_and_normalize(cls, parts: list[str]) -> tuple[str, tuple[str, ...]]:

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -379,11 +379,14 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
             self._str = (self._root + self.parser.sep.join(self._path_parts)) or "."
             return self._str
 
+    def __bytes__(self):
+        return str(self).encode("utf-8")
+
     def __repr__(self):
         return f"{self.__class__.__name__}({str(self)!r})"
 
     def as_uri(self) -> str:
-        return self._ws.config.host + "#workspace" + urlquote_from_bytes(bytes(self))
+        return f"{self._ws.config.host}#workspace{urlquote_from_bytes(bytes(self))}"
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -640,6 +640,17 @@ def test_home_directory():
     assert str(result) == "/Users/test_user"
 
 
+def test_absolute() -> None:
+    """This is only supported for absolute paths.
+
+    Otherwise it depends on the current working directory which isn't supported."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/absolute/path").absolute() == WorkspacePath(ws, "/absolute/path")
+    with pytest.raises(NotImplementedError):
+        _ = WorkspacePath(ws, "relative/path").absolute()
+
+
 def test_is_dir_when_object_type_is_directory():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -260,6 +260,17 @@ def test_with_suffix() -> None:
         _ = WorkspacePath(ws, "/").with_suffix(".txt")
 
 
+def test_as_uri() -> None:
+    """Verify that the URI that corresponds to a path can be generated."""
+    ws = create_autospec(WorkspaceClient)
+    ws.config.host = "https://example.com/instance"
+
+    ws_path = "/tmp/file with spaces.md"
+    expected_url = "https://example.com/instance#workspace/tmp/file%20with%20spaces.md"
+
+    assert WorkspacePath(ws, ws_path).as_uri() == expected_url
+
+
 @pytest.mark.parametrize(
     ("path", "parent"),
     [

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,3 +1,5 @@
+import os
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from unittest.mock import create_autospec, patch
 
 import pytest
@@ -11,6 +13,376 @@ from databricks.sdk.service.workspace import (
 )
 
 from databricks.labs.blueprint.paths import WorkspacePath
+
+
+def test_empty_init() -> None:
+    """Ensure that basic initialization works."""
+    ws = create_autospec(WorkspaceClient)
+
+    # Simple initialisation; the empty path is valid.
+    WorkspacePath(ws)
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        # Some absolute paths.
+        (["/foo/bar"], ("/", ("/", "foo", "bar"))),
+        (["/", "foo", "bar"], ("/", ("/", "foo", "bar"))),
+        (["/", "foo/bar"], ("/", ("/", "foo", "bar"))),
+        (["/", "foo", "bar/baz"], ("/", ("/", "foo", "bar", "baz"))),
+        # Some relative paths.
+        (["foo/bar"], ("", ("foo", "bar"))),
+        (["foo", "bar"], ("", ("foo", "bar"))),
+        (["foo", "/bar"], ("/", ("/", "bar"))),
+        # Some paths with mixed components of Path types.
+        (["/", "foo", PurePosixPath("bar/baz")], ("/", ("/", "foo", "bar", "baz"))),
+        (["/", "foo", PureWindowsPath("config.sys")], ("/", ("/", "foo", "config.sys"))),
+        (["/", "foo", PurePath("bar")], ("/", ("/", "foo", "bar"))),
+        # Some corner cases: empty, root and trailing '/'.
+        ([], ("", ())),
+        (["/"], ("/", ("/",))),
+        (["/foo/"], ("/", ("/", "foo"))),
+        # Intermediate '.' are supposed to be dropped during normalization.
+        (["/foo/./bar"], ("/", ("/", "foo", "bar"))),
+    ],
+    ids=lambda param: f"WorkspacePath({param!r})" if isinstance(param, list) else repr(param),
+)
+def test_init(args: list[str | PurePath], expected: tuple[str, list[str]]) -> None:
+    """Ensure that initialization with various combinations of segments works as expected."""
+    ws = create_autospec(WorkspaceClient)
+
+    # Run the test.
+    p = WorkspacePath(ws, Path(*args))
+
+    # Validate the initialisation results.
+    assert (p.drive, p.root, p.parts) == ("", *expected)
+
+
+def test_init_error() -> None:
+    """Ensure that we detect initialisation with non-string or path-like path components."""
+    ws = create_autospec(WorkspaceClient)
+
+    expected_msg = "argument should be a str or an os.PathLib object where __fspath__ returns a str, not 'int'"
+    with pytest.raises(TypeError, match=expected_msg):
+        WorkspacePath(ws, 12)  # type: ignore[arg-type]
+
+
+def test_equality() -> None:
+    """Test that Workspace paths can be compared with each other for equality."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/foo/bar") == WorkspacePath(ws, Path("/", "foo", "bar"))
+    assert WorkspacePath(ws, "foo/bar") == WorkspacePath(ws, Path("foo", "bar"))
+    assert WorkspacePath(ws, "/foo/bar") != WorkspacePath(ws, Path("foo", "bar"))
+
+    assert WorkspacePath(ws, "/foo/bar") != Path("foo", "bar")
+    assert Path("/foo/bar") != WorkspacePath(ws, "/foo/bar")
+
+
+def test_hash() -> None:
+    """Test that equal Workspace paths have the same hash value."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert hash(WorkspacePath(ws, "/foo/bar")) == hash(WorkspacePath(ws, Path("/", "foo", "bar")))
+    assert hash(WorkspacePath(ws, "foo/bar")) == hash(WorkspacePath(ws, Path("foo", "bar")))
+
+
+@pytest.mark.parametrize(
+    "increasing_paths",
+    [
+        ("/foo", "/foo/bar", "/foo/baz"),
+        ("foo", "foo/bar", "foo/baz"),
+    ],
+)
+def test_comparison(increasing_paths: tuple[str | list[str], str | list[str], str | list[str]]) -> None:
+    """Test that comparing paths works as expected."""
+    ws = create_autospec(WorkspaceClient)
+
+    p1, p2, p3 = (WorkspacePath(ws, p) for p in increasing_paths)
+    assert p1 < p2 < p3
+    assert p1 <= p2 <= p2 <= p3
+    assert p3 > p2 > p1
+    assert p3 >= p2 >= p2 > p1
+
+
+def test_comparison_errors() -> None:
+    """Test that comparing Workspace paths with other types yields the error we expect, irrespective of comparison order."""
+    ws = create_autospec(WorkspaceClient)
+
+    with pytest.raises(TypeError, match="'<' not supported between instances"):
+        _ = WorkspacePath(ws, "foo") < PurePosixPath("foo")
+    with pytest.raises(TypeError, match="'>' not supported between instances"):
+        _ = WorkspacePath(ws, "foo") > PurePosixPath("foo")
+    with pytest.raises(TypeError, match="'<=' not supported between instances"):
+        _ = WorkspacePath(ws, "foo") <= PurePosixPath("foo")
+    with pytest.raises(TypeError, match="'>=' not supported between instances"):
+        _ = WorkspacePath(ws, "foo") >= PurePosixPath("foo")
+    with pytest.raises(TypeError, match="'<' not supported between instances"):
+        _ = PurePosixPath("foo") < WorkspacePath(ws, "foo")
+    with pytest.raises(TypeError, match="'>' not supported between instances"):
+        _ = PurePosixPath("foo") > WorkspacePath(ws, "foo")
+    with pytest.raises(TypeError, match="'<=' not supported between instances"):
+        _ = PurePosixPath("foo") <= WorkspacePath(ws, "foo")
+    with pytest.raises(TypeError, match="'>=' not supported between instances"):
+        _ = PurePosixPath("foo") >= WorkspacePath(ws, "foo")
+
+
+def test_drive() -> None:
+    """Test that the drive is empty for our paths."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/foo").drive == ""
+    assert WorkspacePath(ws, "foo").root == ""
+
+
+def test_root() -> None:
+    """Test that absolute paths have the '/' root and relative paths do not."""
+    # More comprehensive tests are part of test_init()
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/foo").root == "/"
+    assert WorkspacePath(ws, "foo").root == ""
+
+
+def test_anchor() -> None:
+    """Test that the anchor for absolute paths is '/' and empty for relative paths."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/foo").anchor == "/"
+    assert WorkspacePath(ws, "foo").anchor == ""
+
+
+def test_pathlike_error() -> None:
+    """Paths are "path-like" but Workspace ones aren't, so verify that triggers an error."""
+    ws = create_autospec(WorkspaceClient)
+    p = WorkspacePath(ws, "/some/path")
+
+    with pytest.raises(NotImplementedError, match="Workspace paths are not path-like"):
+        _ = os.fspath(p)
+
+
+def test_name() -> None:
+    """Test that the last part of the path is properly noted as the name."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/foo/bar").name == "bar"
+    assert WorkspacePath(ws, "/foo/").name == "foo"
+    assert WorkspacePath(ws, "/").name == ""
+    assert WorkspacePath(ws, Path()).name == ""
+
+
+def test_parts() -> None:
+    """Test that parts returns the anchor and path components."""
+    # More comprehensive tests are part of test_init()
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/foo/bar").parts == ("/", "foo", "bar")
+    assert WorkspacePath(ws, "/foo/").parts == ("/", "foo")
+    assert WorkspacePath(ws, "/").parts == ("/",)
+    assert WorkspacePath(ws, "foo/bar").parts == ("foo", "bar")
+    assert WorkspacePath(ws, "foo/").parts == ("foo",)
+
+
+def test_suffix() -> None:
+    """Test that the suffix is correctly extracted."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/path/to/distribution.tar.gz").suffix == ".gz"
+    assert WorkspacePath(ws, "/no/suffix/here").suffix == ""
+
+
+def test_suffixes() -> None:
+    """Test that multiple suffixes are correctly extracted."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/path/to/distribution.tar.gz").suffixes == [".tar", ".gz"]
+    assert WorkspacePath(ws, "/path/to/file.txt").suffixes == [".txt"]
+    assert WorkspacePath(ws, "/no/suffix/here").suffixes == []
+
+
+def test_stem() -> None:
+    """Test that the stem is correctly extracted."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/path/to/distribution.tar.gz").stem == "distribution.tar"
+    assert WorkspacePath(ws, "/path/to/file.txt").stem == "file"
+    assert WorkspacePath(ws, "/no/suffix/here").stem == "here"
+
+
+def test_with_name() -> None:
+    """Test that the name in a path can be replaced."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/path/to/notebook.py").with_name("requirements.txt") == WorkspacePath(
+        ws, "/path/to/requirements.txt"
+    )
+    assert WorkspacePath(ws, "relative/notebook.py").with_name("requirements.txt") == WorkspacePath(
+        ws, "relative/requirements.txt"
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "name"),
+    [
+        # Invalid names.
+        ("/a/path", "invalid/replacement"),
+        ("/a/path", ""),
+        ("/a/path", "."),
+        # Invalid paths for using with_name()
+        ("/", "file.txt"),
+        ("", "file.txt"),
+    ],
+)
+def test_with_name_errors(path, name) -> None:
+    """Test that various forms of invalid .with_name() invocations are detected."""
+    ws = create_autospec(WorkspaceClient)
+
+    with pytest.raises(ValueError):
+        _ = WorkspacePath(ws, path).with_name(name)
+
+
+def test_with_stem() -> None:
+    """Test that the stem in a path can be replaced."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/dir/file.txt").with_stem("README") == WorkspacePath(ws, "/dir/README.txt")
+
+
+def test_with_suffix() -> None:
+    """Test that the suffix of a path can be replaced, and that some errors are handled."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/dir/README.txt").with_suffix(".md") == WorkspacePath(ws, "/dir/README.md")
+    with pytest.raises(ValueError, match="[Ii]nvalid suffix"):
+        _ = WorkspacePath(ws, "/dir/README.txt").with_suffix("txt")
+    with pytest.raises(ValueError, match="empty name"):
+        _ = WorkspacePath(ws, "/").with_suffix(".txt")
+
+
+def test_relative_to() -> None:
+    """Test that it is possible to get the relative path between two paths."""
+    ws = create_autospec(WorkspaceClient)
+
+    # Basics.
+    assert WorkspacePath(ws, "/home/bob").relative_to("/") == WorkspacePath(ws, "home/bob")
+    assert WorkspacePath(ws, "/home/bob").relative_to("/home") == WorkspacePath(ws, "bob")
+    assert WorkspacePath(ws, "/home/bob").relative_to("/./home") == WorkspacePath(ws, "bob")
+    assert WorkspacePath(ws, "foo/bar/baz").relative_to("foo") == WorkspacePath(ws, "bar/baz")
+    assert WorkspacePath(ws, "foo/bar/baz").relative_to("foo/bar") == WorkspacePath(ws, "baz")
+    assert WorkspacePath(ws, "foo/bar/baz").relative_to("foo/./bar") == WorkspacePath(ws, "baz")
+
+    # Walk-up (3.12+) behaviour.
+    assert WorkspacePath(ws, "/home/bob").relative_to("/usr", walk_up=True) == WorkspacePath(ws, "../home/bob")
+
+    # Check some errors.
+    with pytest.raises(ValueError, match="different anchors"):
+        _ = WorkspacePath(ws, "/home/bob").relative_to("home")
+    with pytest.raises(ValueError, match="not in the subpath"):
+        _ = WorkspacePath(ws, "/home/bob").relative_to("/usr")
+    with pytest.raises(ValueError, match="cannot be walked"):
+        _ = WorkspacePath(ws, "/home/bob").relative_to("/home/../usr", walk_up=True)
+
+
+@pytest.mark.parametrize(
+    ("path", "parent"),
+    [
+        ("/foo/bar/baz", "/foo/bar"),
+        ("/", "/"),
+        (".", "."),
+        ("foo/bar", "foo"),
+        ("foo", "."),
+    ],
+)
+def test_parent(path, parent) -> None:
+    """Test that the parent of a path is properly calculated."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, path).parent == WorkspacePath(ws, parent)
+
+
+@pytest.mark.parametrize(
+    ("path", "parents"),
+    [
+        ("/foo/bar/baz", ("/foo/bar", "/foo", "/")),
+        ("/", ()),
+        (".", ()),
+        ("foo/bar", ("foo", ".")),
+        ("foo", (".",)),
+    ],
+)
+def test_parents(path, parents) -> None:
+    """Test that each of the parents of a path is returned."""
+    ws = create_autospec(WorkspaceClient)
+
+    expected_parents = tuple(WorkspacePath(ws, parent) for parent in parents)
+    assert tuple(WorkspacePath(ws, path).parents) == expected_parents
+
+
+def test_is_relative_to() -> None:
+    """Test detection of whether a path is relative to the target."""
+    ws = create_autospec(WorkspaceClient)
+
+    # Basics where it's true.
+    assert WorkspacePath(ws, "/home/bob").is_relative_to("/")
+    assert WorkspacePath(ws, "/home/bob").is_relative_to("/home")
+    assert WorkspacePath(ws, "/home/bob").is_relative_to("/./home")
+    assert WorkspacePath(ws, "foo/bar/baz").is_relative_to("foo")
+    assert WorkspacePath(ws, "foo/bar/baz").is_relative_to("foo/bar")
+    assert WorkspacePath(ws, "foo/bar/baz").is_relative_to("foo/./bar")
+
+    # Some different situations where it isn't.
+    assert not WorkspacePath(ws, "/home/bob").is_relative_to("home")  # Different anchor.
+    assert not WorkspacePath(ws, "/home/bob").is_relative_to("/usr")  # Not a prefix.
+
+
+def test_is_absolute() -> None:
+    """Test detection of absolute versus relative paths."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/foo/bar").is_absolute()
+    assert WorkspacePath(ws, "/").is_absolute()
+    assert not WorkspacePath(ws, "foo/bar").is_absolute()
+    assert not WorkspacePath(ws, ".").is_absolute()
+
+
+def test_is_reserved() -> None:
+    """Test detection of reserved paths (which don't exist with Workspace paths)."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert not WorkspacePath(ws, "NUL").is_reserved()
+
+
+def test_joinpath() -> None:
+    """Test that paths can be joined."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/home").joinpath("bob") == WorkspacePath(ws, "/home/bob")
+    assert WorkspacePath(ws, "/home").joinpath(WorkspacePath(ws, "bob")) == WorkspacePath(ws, "/home/bob")
+    assert WorkspacePath(ws, "/home").joinpath(PurePosixPath("bob")) == WorkspacePath(ws, "/home/bob")
+    assert WorkspacePath(ws, "/usr").joinpath("local", "bin") == WorkspacePath(ws, "/usr/local/bin")
+    assert WorkspacePath(ws, "home").joinpath("jane") == WorkspacePath(ws, "home/jane")
+
+
+def test_match() -> None:
+    """Test that glob matching works."""
+    ws = create_autospec(WorkspaceClient)
+
+    # Relative patterns, match from the right.
+    assert WorkspacePath(ws, "foo/bar/file.txt").match("*.txt")
+    assert WorkspacePath(ws, "/foo/bar/file.txt").match("bar/*.txt")
+    assert not WorkspacePath(ws, "/foo/bar/file.txt").match("foo/*.txt")
+
+    # Absolute patterns, match from the left (and only against absolute paths)
+    assert WorkspacePath(ws, "/file.txt").match("/*.txt")
+    assert not WorkspacePath(ws, "foo/bar/file.txt").match("/*.txt")
+
+    # Case-sensitive by default, but can be overridden.
+    assert not WorkspacePath(ws, "file.txt").match("*.TXT")
+    # assert WorkspacePath(ws, "file.txt").match("*.TXT", case_sensitive=False)
+
+    # No recursive globs.
+    assert not WorkspacePath(ws, "/foo/bar/file.txt").match("/**/*.txt")
 
 
 def test_exists_when_path_exists() -> None:
@@ -127,7 +499,7 @@ def test_suffix_when_file_has_extension() -> None:
 def test_suffix_when_file_is_notebook_and_language_matches() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
-    workspace_path._object_info = ObjectInfo(language=Language.PYTHON, object_type=ObjectType.NOTEBOOK)
+    workspace_path._cached_object_info = ObjectInfo(language=Language.PYTHON, object_type=ObjectType.NOTEBOOK)
     assert workspace_path.suffix == ".py"
 
 
@@ -204,13 +576,6 @@ def test_unlink_non_existing_file() -> None:
     ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
     with pytest.raises(FileNotFoundError):
         workspace_path.unlink()
-
-
-def test_relative_to() -> None:
-    ws = create_autospec(WorkspaceClient)
-    workspace_path = WorkspacePath(ws, "/test/path/subpath")
-    result = workspace_path.relative_to("/test/path")
-    assert str(result) == "subpath"
 
 
 def test_as_fuse_in_databricks_runtime() -> None:
@@ -300,6 +665,7 @@ def test_is_notebook_when_databricks_error_occurs() -> None:
     assert workspace_path.is_notebook() is False
 
 
+@pytest.mark.xfail(reason="Implementation pending.")
 def test_globbing_when_nested_json_files_exist() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -499,15 +499,17 @@ def test_suffix_when_file_has_extension():
 
 def test_suffix_when_file_is_notebook_and_language_matches():
     ws = create_autospec(WorkspaceClient)
+    ws.workspace.get_status.return_value = ObjectInfo(language=Language.PYTHON, object_type=ObjectType.NOTEBOOK)
+
     workspace_path = WorkspacePath(ws, "/test/path")
-    workspace_path._cached_object_info = ObjectInfo(language=Language.PYTHON, object_type=ObjectType.NOTEBOOK)
     assert workspace_path.suffix == ".py"
 
 
 def test_suffix_when_file_is_notebook_and_language_does_not_match():
     ws = create_autospec(WorkspaceClient)
+    ws.workspace.get_status.return_value = ObjectInfo(language=None, object_type=ObjectType.NOTEBOOK)
+
     workspace_path = WorkspacePath(ws, "/test/path")
-    workspace_path._object_info.language = None
     assert workspace_path.suffix == ""
 
 

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -410,132 +410,132 @@ def test_match() -> None:
     assert not WorkspacePath(ws, "/foo/bar/file.txt").match("/**/*.txt")
 
 
-def test_exists_when_path_exists() -> None:
+def test_exists_when_path_exists():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = True
     assert workspace_path.exists()
 
 
-def test_exists_when_path_does_not_exist() -> None:
+def test_exists_when_path_does_not_exist():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
     assert not workspace_path.exists()
 
 
-def test_mkdir_creates_directory() -> None:
+def test_mkdir_creates_directory():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.mkdir()
     ws.workspace.mkdirs.assert_called_once_with("/test/path")
 
 
-def test_rmdir_removes_directory() -> None:
+def test_rmdir_removes_directory():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.rmdir()
     ws.workspace.delete.assert_called_once_with("/test/path", recursive=False)
 
 
-def test_is_dir_when_path_is_directory() -> None:
+def test_is_dir_when_path_is_directory():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.DIRECTORY)
     assert workspace_path.is_dir()
 
 
-def test_is_dir_when_path_is_not_directory() -> None:
+def test_is_dir_when_path_is_not_directory():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.FILE)
     assert not workspace_path.is_dir()
 
 
-def test_is_file_when_path_is_file() -> None:
+def test_is_file_when_path_is_file():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.FILE)
     assert workspace_path.is_file()
 
 
-def test_is_file_when_path_is_not_file() -> None:
+def test_is_file_when_path_is_not_file():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.DIRECTORY)
     assert not workspace_path.is_file()
 
 
-def test_is_notebook_when_path_is_notebook() -> None:
+def test_is_notebook_when_path_is_notebook():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.NOTEBOOK)
     assert workspace_path.is_notebook()
 
 
-def test_is_notebook_when_path_is_not_notebook() -> None:
+def test_is_notebook_when_path_is_not_notebook():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.FILE)
     assert not workspace_path.is_notebook()
 
 
-def test_open_file_in_read_binary_mode() -> None:
+def test_open_file_in_read_binary_mode():
     ws = create_autospec(WorkspaceClient)
     ws.workspace.download.return_value.__enter__.return_value.read.return_value = b"test"
     workspace_path = WorkspacePath(ws, "/test/path")
     assert workspace_path.read_bytes() == b"test"
 
 
-def test_open_file_in_write_binary_mode() -> None:
+def test_open_file_in_write_binary_mode():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.write_bytes(b"test")
     ws.workspace.upload.assert_called_with("/test/path", b"test", format=ImportFormat.AUTO)
 
 
-def test_open_file_in_read_text_mode() -> None:
+def test_open_file_in_read_text_mode():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.download.return_value.__enter__.return_value.read.return_value = b"test"
     assert workspace_path.read_text() == "test"
 
 
-def test_open_file_in_write_text_mode() -> None:
+def test_open_file_in_write_text_mode():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.write_text("test")
     ws.workspace.upload.assert_called_with("/test/path", "test", format=ImportFormat.AUTO)
 
 
-def test_open_file_in_invalid_mode() -> None:
+def test_open_file_in_invalid_mode():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     with pytest.raises(ValueError):
         workspace_path.open(mode="invalid")
 
 
-def test_suffix_when_file_has_extension() -> None:
+def test_suffix_when_file_has_extension():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path.py")
     assert workspace_path.suffix == ".py"
 
 
-def test_suffix_when_file_is_notebook_and_language_matches() -> None:
+def test_suffix_when_file_is_notebook_and_language_matches():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._cached_object_info = ObjectInfo(language=Language.PYTHON, object_type=ObjectType.NOTEBOOK)
     assert workspace_path.suffix == ".py"
 
 
-def test_suffix_when_file_is_notebook_and_language_does_not_match() -> None:
+def test_suffix_when_file_is_notebook_and_language_does_not_match():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.language = None
     assert workspace_path.suffix == ""
 
 
-def test_suffix_when_file_is_not_notebook() -> None:
+def test_suffix_when_file_is_not_notebook():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     with patch("databricks.labs.blueprint.paths.WorkspacePath.is_notebook") as mock_is_notebook:
@@ -543,35 +543,35 @@ def test_suffix_when_file_is_not_notebook() -> None:
         assert workspace_path.suffix == ""
 
 
-def test_mkdir_creates_directory_with_valid_mode() -> None:
+def test_mkdir_creates_directory_with_valid_mode():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.mkdir(mode=0o600)
     ws.workspace.mkdirs.assert_called_once_with("/test/path")
 
 
-def test_mkdir_raises_error_with_invalid_mode() -> None:
+def test_mkdir_raises_error_with_invalid_mode():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     with pytest.raises(ValueError):
         workspace_path.mkdir(mode=0o700)
 
 
-def test_rmdir_removes_directory_non_recursive() -> None:
+def test_rmdir_removes_directory_non_recursive():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.rmdir()
     ws.workspace.delete.assert_called_once_with("/test/path", recursive=False)
 
 
-def test_rmdir_removes_directory_recursive() -> None:
+def test_rmdir_removes_directory_recursive():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.rmdir(recursive=True)
     ws.workspace.delete.assert_called_once_with("/test/path", recursive=True)
 
 
-def test_rename_file_without_overwrite() -> None:
+def test_rename_file_without_overwrite():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.download.return_value.__enter__.return_value.read.return_value = b"test"
@@ -579,7 +579,7 @@ def test_rename_file_without_overwrite() -> None:
     ws.workspace.upload.assert_called_once_with("/new/path", b"test", format=ImportFormat.AUTO, overwrite=False)
 
 
-def test_rename_file_with_overwrite() -> None:
+def test_rename_file_with_overwrite():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.download.return_value.__enter__.return_value.read.return_value = b"test"
@@ -587,7 +587,7 @@ def test_rename_file_with_overwrite() -> None:
     ws.workspace.upload.assert_called_once_with("/new/path", b"test", format=ImportFormat.AUTO, overwrite=True)
 
 
-def test_unlink_existing_file() -> None:
+def test_unlink_existing_file():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = True
@@ -595,7 +595,7 @@ def test_unlink_existing_file() -> None:
     ws.workspace.delete.assert_called_once_with("/test/path")
 
 
-def test_unlink_non_existing_file() -> None:
+def test_unlink_non_existing_file():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
@@ -603,7 +603,7 @@ def test_unlink_non_existing_file() -> None:
         workspace_path.unlink()
 
 
-def test_as_fuse_in_databricks_runtime() -> None:
+def test_as_fuse_in_databricks_runtime():
     with patch.dict("os.environ", {"DATABRICKS_RUNTIME_VERSION": "14.3"}):
         ws = create_autospec(WorkspaceClient)
         workspace_path = WorkspacePath(ws, "/test/path")
@@ -611,7 +611,7 @@ def test_as_fuse_in_databricks_runtime() -> None:
         assert str(result) == "/Workspace/test/path"
 
 
-def test_as_fuse_outside_databricks_runtime() -> None:
+def test_as_fuse_outside_databricks_runtime():
     with patch.dict("os.environ", {}, clear=True):
         ws = create_autospec(WorkspaceClient)
         workspace_path = WorkspacePath(ws, "/test/path")
@@ -619,7 +619,7 @@ def test_as_fuse_outside_databricks_runtime() -> None:
         assert str(result) == "/Workspace/test/path"
 
 
-def test_home_directory() -> None:
+def test_home_directory():
     ws = create_autospec(WorkspaceClient)
     ws.current_user.me.return_value.user_name = "test_user"
     workspace_path = WorkspacePath(ws, "/test/path")
@@ -627,63 +627,63 @@ def test_home_directory() -> None:
     assert str(result) == "/Users/test_user"
 
 
-def test_is_dir_when_object_type_is_directory() -> None:
+def test_is_dir_when_object_type_is_directory():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.DIRECTORY
     assert workspace_path.is_dir() is True
 
 
-def test_is_dir_when_object_type_is_not_directory() -> None:
+def test_is_dir_when_object_type_is_not_directory():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.FILE
     assert workspace_path.is_dir() is False
 
 
-def test_is_dir_when_databricks_error_occurs() -> None:
+def test_is_dir_when_databricks_error_occurs():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
     assert workspace_path.is_dir() is False
 
 
-def test_is_file_when_object_type_is_file() -> None:
+def test_is_file_when_object_type_is_file():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.FILE
     assert workspace_path.is_file() is True
 
 
-def test_is_file_when_object_type_is_not_file() -> None:
+def test_is_file_when_object_type_is_not_file():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.DIRECTORY
     assert workspace_path.is_file() is False
 
 
-def test_is_file_when_databricks_error_occurs() -> None:
+def test_is_file_when_databricks_error_occurs():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
     assert workspace_path.is_file() is False
 
 
-def test_is_notebook_when_object_type_is_notebook() -> None:
+def test_is_notebook_when_object_type_is_notebook():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.NOTEBOOK
     assert workspace_path.is_notebook() is True
 
 
-def test_is_notebook_when_object_type_is_not_notebook() -> None:
+def test_is_notebook_when_object_type_is_not_notebook():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.FILE
     assert workspace_path.is_notebook() is False
 
 
-def test_is_notebook_when_databricks_error_occurs() -> None:
+def test_is_notebook_when_databricks_error_occurs():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
@@ -691,7 +691,7 @@ def test_is_notebook_when_databricks_error_occurs() -> None:
 
 
 @pytest.mark.xfail(reason="Implementation pending.")
-def test_globbing_when_nested_json_files_exist() -> None:
+def test_globbing_when_nested_json_files_exist():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.DIRECTORY)

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -13,167 +13,168 @@ from databricks.sdk.service.workspace import (
 from databricks.labs.blueprint.paths import WorkspacePath
 
 
-def test_exists_when_path_exists():
+def test_exists_when_path_exists() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = True
     assert workspace_path.exists()
 
 
-def test_exists_when_path_does_not_exist():
+def test_exists_when_path_does_not_exist() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
-    ws.workspace.get_status.side_effect = NotFound(...)
+    ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
     assert not workspace_path.exists()
 
 
-def test_mkdir_creates_directory():
+def test_mkdir_creates_directory() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.mkdir()
     ws.workspace.mkdirs.assert_called_once_with("/test/path")
 
 
-def test_rmdir_removes_directory():
+def test_rmdir_removes_directory() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.rmdir()
     ws.workspace.delete.assert_called_once_with("/test/path", recursive=False)
 
 
-def test_is_dir_when_path_is_directory():
+def test_is_dir_when_path_is_directory() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.DIRECTORY)
     assert workspace_path.is_dir()
 
 
-def test_is_dir_when_path_is_not_directory():
+def test_is_dir_when_path_is_not_directory() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.FILE)
     assert not workspace_path.is_dir()
 
 
-def test_is_file_when_path_is_file():
+def test_is_file_when_path_is_file() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.FILE)
     assert workspace_path.is_file()
 
 
-def test_is_file_when_path_is_not_file():
+def test_is_file_when_path_is_not_file() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.DIRECTORY)
     assert not workspace_path.is_file()
 
 
-def test_is_notebook_when_path_is_notebook():
+def test_is_notebook_when_path_is_notebook() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.NOTEBOOK)
     assert workspace_path.is_notebook()
 
 
-def test_is_notebook_when_path_is_not_notebook():
+def test_is_notebook_when_path_is_not_notebook() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.FILE)
     assert not workspace_path.is_notebook()
 
 
-def test_open_file_in_read_binary_mode():
+def test_open_file_in_read_binary_mode() -> None:
     ws = create_autospec(WorkspaceClient)
     ws.workspace.download.return_value.__enter__.return_value.read.return_value = b"test"
     workspace_path = WorkspacePath(ws, "/test/path")
     assert workspace_path.read_bytes() == b"test"
 
 
-def test_open_file_in_write_binary_mode():
+def test_open_file_in_write_binary_mode() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.write_bytes(b"test")
     ws.workspace.upload.assert_called_with("/test/path", b"test", format=ImportFormat.AUTO)
 
 
-def test_open_file_in_read_text_mode():
+def test_open_file_in_read_text_mode() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.download.return_value.__enter__.return_value.read.return_value = b"test"
     assert workspace_path.read_text() == "test"
 
 
-def test_open_file_in_write_text_mode():
+def test_open_file_in_write_text_mode() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.write_text("test")
     ws.workspace.upload.assert_called_with("/test/path", "test", format=ImportFormat.AUTO)
 
 
-def test_open_file_in_invalid_mode():
+def test_open_file_in_invalid_mode() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     with pytest.raises(ValueError):
         workspace_path.open(mode="invalid")
 
 
-def test_suffix_when_file_has_extension():
+def test_suffix_when_file_has_extension() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path.py")
     assert workspace_path.suffix == ".py"
 
 
-def test_suffix_when_file_is_notebook_and_language_matches():
+def test_suffix_when_file_is_notebook_and_language_matches() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info = ObjectInfo(language=Language.PYTHON, object_type=ObjectType.NOTEBOOK)
     assert workspace_path.suffix == ".py"
 
 
-def test_suffix_when_file_is_notebook_and_language_does_not_match():
+def test_suffix_when_file_is_notebook_and_language_does_not_match() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
-    workspace_path._object_info.language = "unknown"
+    workspace_path._object_info.language = None
     assert workspace_path.suffix == ""
 
 
-def test_suffix_when_file_is_not_notebook():
+def test_suffix_when_file_is_not_notebook() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
-    workspace_path.is_notebook = lambda: False
-    assert workspace_path.suffix == ""
+    with patch("databricks.labs.blueprint.paths.WorkspacePath.is_notebook") as mock_is_notebook:
+        mock_is_notebook.return_value = False
+        assert workspace_path.suffix == ""
 
 
-def test_mkdir_creates_directory_with_valid_mode():
+def test_mkdir_creates_directory_with_valid_mode() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.mkdir(mode=0o600)
     ws.workspace.mkdirs.assert_called_once_with("/test/path")
 
 
-def test_mkdir_raises_error_with_invalid_mode():
+def test_mkdir_raises_error_with_invalid_mode() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     with pytest.raises(ValueError):
         workspace_path.mkdir(mode=0o700)
 
 
-def test_rmdir_removes_directory_non_recursive():
+def test_rmdir_removes_directory_non_recursive() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.rmdir()
     ws.workspace.delete.assert_called_once_with("/test/path", recursive=False)
 
 
-def test_rmdir_removes_directory_recursive():
+def test_rmdir_removes_directory_recursive() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path.rmdir(recursive=True)
     ws.workspace.delete.assert_called_once_with("/test/path", recursive=True)
 
 
-def test_rename_file_without_overwrite():
+def test_rename_file_without_overwrite() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.download.return_value.__enter__.return_value.read.return_value = b"test"
@@ -181,7 +182,7 @@ def test_rename_file_without_overwrite():
     ws.workspace.upload.assert_called_once_with("/new/path", b"test", format=ImportFormat.AUTO, overwrite=False)
 
 
-def test_rename_file_with_overwrite():
+def test_rename_file_with_overwrite() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.download.return_value.__enter__.return_value.read.return_value = b"test"
@@ -189,7 +190,7 @@ def test_rename_file_with_overwrite():
     ws.workspace.upload.assert_called_once_with("/new/path", b"test", format=ImportFormat.AUTO, overwrite=True)
 
 
-def test_unlink_existing_file():
+def test_unlink_existing_file() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = True
@@ -197,22 +198,22 @@ def test_unlink_existing_file():
     ws.workspace.delete.assert_called_once_with("/test/path")
 
 
-def test_unlink_non_existing_file():
+def test_unlink_non_existing_file() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
-    ws.workspace.get_status.side_effect = NotFound(...)
+    ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
     with pytest.raises(FileNotFoundError):
         workspace_path.unlink()
 
 
-def test_relative_to():
+def test_relative_to() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path/subpath")
     result = workspace_path.relative_to("/test/path")
     assert str(result) == "subpath"
 
 
-def test_as_fuse_in_databricks_runtime():
+def test_as_fuse_in_databricks_runtime() -> None:
     with patch.dict("os.environ", {"DATABRICKS_RUNTIME_VERSION": "14.3"}):
         ws = create_autospec(WorkspaceClient)
         workspace_path = WorkspacePath(ws, "/test/path")
@@ -220,7 +221,7 @@ def test_as_fuse_in_databricks_runtime():
         assert str(result) == "/Workspace/test/path"
 
 
-def test_as_fuse_outside_databricks_runtime():
+def test_as_fuse_outside_databricks_runtime() -> None:
     with patch.dict("os.environ", {}, clear=True):
         ws = create_autospec(WorkspaceClient)
         workspace_path = WorkspacePath(ws, "/test/path")
@@ -228,7 +229,7 @@ def test_as_fuse_outside_databricks_runtime():
         assert str(result) == "/Workspace/test/path"
 
 
-def test_home_directory():
+def test_home_directory() -> None:
     ws = create_autospec(WorkspaceClient)
     ws.current_user.me.return_value.user_name = "test_user"
     workspace_path = WorkspacePath(ws, "/test/path")
@@ -236,70 +237,70 @@ def test_home_directory():
     assert str(result) == "/Users/test_user"
 
 
-def test_is_dir_when_object_type_is_directory():
+def test_is_dir_when_object_type_is_directory() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.DIRECTORY
     assert workspace_path.is_dir() is True
 
 
-def test_is_dir_when_object_type_is_not_directory():
+def test_is_dir_when_object_type_is_not_directory() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.FILE
     assert workspace_path.is_dir() is False
 
 
-def test_is_dir_when_databricks_error_occurs():
+def test_is_dir_when_databricks_error_occurs() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
-    ws.workspace.get_status.side_effect = NotFound(...)
+    ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
     assert workspace_path.is_dir() is False
 
 
-def test_is_file_when_object_type_is_file():
+def test_is_file_when_object_type_is_file() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.FILE
     assert workspace_path.is_file() is True
 
 
-def test_is_file_when_object_type_is_not_file():
+def test_is_file_when_object_type_is_not_file() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.DIRECTORY
     assert workspace_path.is_file() is False
 
 
-def test_is_file_when_databricks_error_occurs():
+def test_is_file_when_databricks_error_occurs() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
-    ws.workspace.get_status.side_effect = NotFound(...)
+    ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
     assert workspace_path.is_file() is False
 
 
-def test_is_notebook_when_object_type_is_notebook():
+def test_is_notebook_when_object_type_is_notebook() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.NOTEBOOK
     assert workspace_path.is_notebook() is True
 
 
-def test_is_notebook_when_object_type_is_not_notebook():
+def test_is_notebook_when_object_type_is_not_notebook() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     workspace_path._object_info.object_type = ObjectType.FILE
     assert workspace_path.is_notebook() is False
 
 
-def test_is_notebook_when_databricks_error_occurs():
+def test_is_notebook_when_databricks_error_occurs() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
-    ws.workspace.get_status.side_effect = NotFound(...)
+    ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
     assert workspace_path.is_notebook() is False
 
 
-def test_globbing_when_nested_json_files_exist():
+def test_globbing_when_nested_json_files_exist() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
     ws.workspace.get_status.return_value = ObjectInfo(object_type=ObjectType.DIRECTORY)

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -513,10 +513,10 @@ def test_suffix_when_file_is_notebook_and_language_does_not_match():
 
 def test_suffix_when_file_is_not_notebook():
     ws = create_autospec(WorkspaceClient)
+    ws.workspace.get_status.return_value = ObjectInfo(language=Language.PYTHON, object_type=ObjectType.FILE)
+
     workspace_path = WorkspacePath(ws, "/test/path")
-    with patch("databricks.labs.blueprint.paths.WorkspacePath.is_notebook") as mock_is_notebook:
-        mock_is_notebook.return_value = False
-        assert workspace_path.suffix == ""
+    assert workspace_path.suffix == ""
 
 
 def test_mkdir_creates_directory_with_valid_mode():

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -260,30 +260,6 @@ def test_with_suffix() -> None:
         _ = WorkspacePath(ws, "/").with_suffix(".txt")
 
 
-def test_relative_to() -> None:
-    """Test that it is possible to get the relative path between two paths."""
-    ws = create_autospec(WorkspaceClient)
-
-    # Basics.
-    assert WorkspacePath(ws, "/home/bob").relative_to("/") == WorkspacePath(ws, "home/bob")
-    assert WorkspacePath(ws, "/home/bob").relative_to("/home") == WorkspacePath(ws, "bob")
-    assert WorkspacePath(ws, "/home/bob").relative_to("/./home") == WorkspacePath(ws, "bob")
-    assert WorkspacePath(ws, "foo/bar/baz").relative_to("foo") == WorkspacePath(ws, "bar/baz")
-    assert WorkspacePath(ws, "foo/bar/baz").relative_to("foo/bar") == WorkspacePath(ws, "baz")
-    assert WorkspacePath(ws, "foo/bar/baz").relative_to("foo/./bar") == WorkspacePath(ws, "baz")
-
-    # Walk-up (3.12+) behaviour.
-    assert WorkspacePath(ws, "/home/bob").relative_to("/usr", walk_up=True) == WorkspacePath(ws, "../home/bob")
-
-    # Check some errors.
-    with pytest.raises(ValueError, match="different anchors"):
-        _ = WorkspacePath(ws, "/home/bob").relative_to("home")
-    with pytest.raises(ValueError, match="not in the subpath"):
-        _ = WorkspacePath(ws, "/home/bob").relative_to("/usr")
-    with pytest.raises(ValueError, match="cannot be walked"):
-        _ = WorkspacePath(ws, "/home/bob").relative_to("/home/../usr", walk_up=True)
-
-
 @pytest.mark.parametrize(
     ("path", "parent"),
     [
@@ -601,6 +577,30 @@ def test_unlink_non_existing_file():
     ws.workspace.get_status.side_effect = NotFound("Simulated NotFound")
     with pytest.raises(FileNotFoundError):
         workspace_path.unlink()
+
+
+def test_relative_to() -> None:
+    """Test that it is possible to get the relative path between two paths."""
+    ws = create_autospec(WorkspaceClient)
+
+    # Basics.
+    assert WorkspacePath(ws, "/home/bob").relative_to("/") == WorkspacePath(ws, "home/bob")
+    assert WorkspacePath(ws, "/home/bob").relative_to("/home") == WorkspacePath(ws, "bob")
+    assert WorkspacePath(ws, "/home/bob").relative_to("/./home") == WorkspacePath(ws, "bob")
+    assert WorkspacePath(ws, "foo/bar/baz").relative_to("foo") == WorkspacePath(ws, "bar/baz")
+    assert WorkspacePath(ws, "foo/bar/baz").relative_to("foo/bar") == WorkspacePath(ws, "baz")
+    assert WorkspacePath(ws, "foo/bar/baz").relative_to("foo/./bar") == WorkspacePath(ws, "baz")
+
+    # Walk-up (3.12+) behaviour.
+    assert WorkspacePath(ws, "/home/bob").relative_to("/usr", walk_up=True) == WorkspacePath(ws, "../home/bob")
+
+    # Check some errors.
+    with pytest.raises(ValueError, match="different anchors"):
+        _ = WorkspacePath(ws, "/home/bob").relative_to("home")
+    with pytest.raises(ValueError, match="not in the subpath"):
+        _ = WorkspacePath(ws, "/home/bob").relative_to("/usr")
+    with pytest.raises(ValueError, match="cannot be walked"):
+        _ = WorkspacePath(ws, "/home/bob").relative_to("/home/../usr", walk_up=True)
 
 
 def test_as_fuse_in_databricks_runtime():

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -364,6 +364,31 @@ def test_joinpath() -> None:
     assert WorkspacePath(ws, "home").joinpath("jane") == WorkspacePath(ws, "home/jane")
 
 
+def test_join_dsl() -> None:
+    """Test that the /-based DSL can be used to build new paths."""
+    ws = create_autospec(WorkspaceClient)
+
+    # First the forward style options.
+    assert WorkspacePath(ws, "/home/bob") / "data" == WorkspacePath(ws, "/home/bob/data")
+    assert WorkspacePath(ws, "/home/bob") / "data" / "base" == WorkspacePath(ws, "/home/bob/data/base")
+    assert WorkspacePath(ws, "/home/bob") / "data/base" == WorkspacePath(ws, "/home/bob/data/base")
+    assert WorkspacePath(ws, "home") / "bob" == WorkspacePath(ws, "home/bob")
+    # New root
+    assert WorkspacePath(ws, "whatever") / "/home" == WorkspacePath(ws, "/home")
+    # Mix types: eventual type is less-associative
+    assert WorkspacePath(ws, "/home/bob") / PurePosixPath("data") == WorkspacePath(ws, "/home/bob/data")
+
+    # Building from the other direction; same as above.
+    assert "/home/bob" / WorkspacePath(ws, "data") == WorkspacePath(ws, "/home/bob/data")
+    assert "/home/bob" / WorkspacePath(ws, "data") / "base" == WorkspacePath(ws, "/home/bob/data/base")
+    assert "/home/bob" / WorkspacePath(ws, "data/base") == WorkspacePath(ws, "/home/bob/data/base")
+    assert "home" / WorkspacePath(ws, "bob") == WorkspacePath(ws, "home/bob")
+    # New root
+    assert "whatever" / WorkspacePath(ws, "/home") == WorkspacePath(ws, "/home")
+    # Mix types: eventual type is less-associative
+    assert PurePosixPath("/home/bob") / WorkspacePath(ws, "data") == PurePosixPath("/home/bob/data")
+
+
 def test_match() -> None:
     """Test that glob matching works."""
     ws = create_autospec(WorkspaceClient)


### PR DESCRIPTION
This PR is stacked on #122 and fixes some things that the integration tests expect but weren't covered by unit tests:

 - `.as_uri()`, which internally depends on the `__bytes__()` dunder method.
 - `.absolute()`, which is supported in the trivial (no-op) case.

Both underlying implementations depend on PathLib internals that changed across python versions.

With this PR applied, some integrations still fail due to missing globbing support, which is implemented as #125.