### PR TITLE
Fix `.as_uri()` and `.absolute()` implementations for `WorkspacePath` 

### DIFF
--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -237,11 +237,14 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
             self._str = (self._root + self.parser.sep.join(self._path_parts)) or "."
             return self._str
 
+    def __bytes__(self):
+        return str(self).encode("utf-8")
+
     def __repr__(self):
         return f"{self.__class__.__name__}({str(self)!r})"
 
     def as_uri(self) -> str:
-        return self._ws.config.host + "#workspace" + urlquote_from_bytes(bytes(self))
+        return f"{self._ws.config.host}#workspace{urlquote_from_bytes(bytes(self))}"
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -617,12 +617,16 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
 
     def glob(self, pattern, *, case_sensitive=None):
         pattern_parts = self._prepare_pattern(pattern)
-        selector = _Selector.parse(pattern_parts, case_sensitive=case_sensitive if case_sensitive is not None else True)
+        if case_sensitive is None:
+            case_sensitive = True
+        selector = _Selector.parse(pattern_parts, case_sensitive=case_sensitive)
         yield from selector(self)
 
     def rglob(self, pattern, *, case_sensitive=None):
         pattern_parts = ("**", *self._prepare_pattern(pattern))
-        selector = _Selector.parse(pattern_parts, case_sensitive=case_sensitive if case_sensitive is not None else True)
+        if case_sensitive is None:
+            case_sensitive = True
+        selector = _Selector.parse(pattern_parts, case_sensitive=case_sensitive)
         yield from selector(self)
 
 

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -555,6 +555,11 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
         """Return the absolute path of the file or directory in Databricks Workspace."""
         return self
 
+    def absolute(self):
+        if self.is_absolute():
+            return self
+        return self.with_segments(self.cwd(), self)
+
     def is_dir(self):
         """Return True if the path points to a directory in Databricks Workspace."""
         try:

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -664,6 +664,17 @@ def test_home_directory():
     assert str(result) == "/Users/test_user"
 
 
+def test_absolute() -> None:
+    """This is only supported for absolute paths.
+
+    Otherwise it depends on the current working directory which isn't supported."""
+    ws = create_autospec(WorkspaceClient)
+
+    assert WorkspacePath(ws, "/absolute/path").absolute() == WorkspacePath(ws, "/absolute/path")
+    with pytest.raises(NotImplementedError):
+        _ = WorkspacePath(ws, "relative/path").absolute()
+
+
 def test_is_dir_when_object_type_is_directory():
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -262,6 +262,17 @@ def test_with_suffix() -> None:
         _ = WorkspacePath(ws, "/").with_suffix(".txt")
 
 
+def test_as_uri() -> None:
+    """Verify that the URI that corresponds to a path can be generated."""
+    ws = create_autospec(WorkspaceClient)
+    ws.config.host = "https://example.com/instance"
+
+    ws_path = "/tmp/file with spaces.md"
+    expected_url = "https://example.com/instance#workspace/tmp/file%20with%20spaces.md"
+
+    assert WorkspacePath(ws, ws_path).as_uri() == expected_url
+
+
 @pytest.mark.parametrize(
     ("path", "parent"),
     [


### PR DESCRIPTION
This PR is a rebase that replaces #126 and fixes some things that the integration tests expect but weren't covered by unit tests:

 - `.as_uri()`, which internally depends on the `__bytes__()` dunder method.
 - `.absolute()`, which is supported in the trivial (no-op) case.

Both underlying implementations depend on PathLib internals that changed across python versions.
