### PR TITLE
`WorkspacePath` fixes for the `.resolve()` implementation

### DIFF
--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -553,7 +553,11 @@ class WorkspacePath(Path):  # pylint: disable=too-many-public-methods
 
     def resolve(self, strict=False):
         """Return the absolute path of the file or directory in Databricks Workspace."""
-        return self
+        absolute = self.absolute()
+        if strict and not absolute.exists():
+            msg = f"Path does not exist: {self}"
+            raise FileNotFoundError(msg)
+        return absolute
 
     def absolute(self):
         if self.is_absolute():

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -664,6 +664,24 @@ def test_home_directory() -> None:
     assert str(result) == "/Users/test_user"
 
 
+def test_resolve() -> None:
+    """This is only supported for absolute paths.
+
+    Otherwise it depends on the current working directory which isn't supported."""
+    ws = create_autospec(WorkspaceClient)
+    ws.workspace.get_status.side_effect = (
+        ObjectInfo(path="/path/that/exists", object_type=ObjectType.FILE),
+        NotFound("Simulated NotFound"),
+    )
+
+    assert WorkspacePath(ws, "/absolute/path").resolve() == WorkspacePath(ws, "/absolute/path")
+    assert WorkspacePath(ws, "/path/that/exists").resolve(strict=True) == WorkspacePath(ws, "/path/that/exists")
+    with pytest.raises(FileNotFoundError):
+        _ = WorkspacePath(ws, "/path/that/does/not/exist").resolve(strict=True)
+    with pytest.raises(NotImplementedError):
+        _ = WorkspacePath(ws, "relative/path").resolve()
+
+
 def test_absolute() -> None:
     """This is only supported for absolute paths.
 


### PR DESCRIPTION
This PR updates the `.resolve()` implementation for `WorkspacePath` so that:

 - It now properly fails on (unsupported) relative paths instead of returning the path as-is.
 - The `strict` argument is now checked: `FileNotFoundError` will be raised if `strict` is true and the path doesn't exist.
