### PR TITLE
Added `DBFSPath` as `os.PathLike` implementation

### DIFF
--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -204,6 +204,52 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
             return sep, part.lstrip(sep)
         return "", part
 
+    @abstractmethod
+    def as_uri(self) -> str: ...
+
+    @abstractmethod
+    def as_fuse(self) -> Path: ...
+
+    @abstractmethod
+    def exists(self, *, follow_symlinks: bool = True) -> bool: ...
+
+    @abstractmethod
+    def mkdir(self, mode: int = 0o600, parents: bool = True, exist_ok: bool = True) -> None: ...
+
+    @abstractmethod
+    def rmdir(self, recursive: bool = False) -> None: ...
+
+    @abstractmethod
+    def unlink(self, missing_ok: bool = False) -> None: ...
+
+    @abstractmethod
+    def open(
+        self,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ): ...
+
+    @abstractmethod
+    def is_dir(self) -> bool: ...
+
+    @abstractmethod
+    def is_file(self) -> bool: ...
+
+    @abstractmethod
+    def rename(self: P, target: str | bytes | os.PathLike) -> P: ...
+
+    @abstractmethod
+    def replace(self: P, target: str | bytes | os.PathLike) -> P: ...
+
+    @abstractmethod
+    def expanduser(self: P) -> P: ...
+
+    @abstractmethod
+    def iterdir(self: P) -> Generator[P, None, None]: ...
+
     def __reduce__(self) -> NoReturn:
         # Cannot support pickling because we can't pickle the workspace client.
         msg = f"Pickling {self.__class__.__qualname__} paths is not supported."
@@ -445,12 +491,6 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
         """Return the user's home directory. Adapted from pathlib.Path"""
         return type(self)(self._ws, "~").expanduser()
 
-    @abstractmethod
-    def rename(self: P, target: str | bytes | os.PathLike) -> P: ...
-
-    @abstractmethod
-    def replace(self: P, target: str | bytes | os.PathLike) -> P: ...
-
     def _return_false(self) -> bool:
         return False
 
@@ -513,46 +553,6 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
             case_sensitive = True
         selector = _Selector.parse(pattern_parts, case_sensitive=case_sensitive)
         yield from selector(self)
-
-    @abstractmethod
-    def as_uri(self) -> str: ...
-
-    @abstractmethod
-    def as_fuse(self) -> Path: ...
-
-    @abstractmethod
-    def exists(self, *, follow_symlinks: bool = True) -> bool: ...
-
-    @abstractmethod
-    def mkdir(self, mode: int = 0o600, parents: bool = True, exist_ok: bool = True) -> None: ...
-
-    @abstractmethod
-    def rmdir(self, recursive: bool = False) -> None: ...
-
-    @abstractmethod
-    def unlink(self, missing_ok: bool = False) -> None: ...
-
-    @abstractmethod
-    def open(
-        self,
-        mode: str = "r",
-        buffering: int = -1,
-        encoding: str | None = None,
-        errors: str | None = None,
-        newline: str | None = None,
-    ): ...
-
-    @abstractmethod
-    def is_dir(self) -> bool: ...
-
-    @abstractmethod
-    def is_file(self) -> bool: ...
-
-    @abstractmethod
-    def expanduser(self: P) -> P: ...
-
-    @abstractmethod
-    def iterdir(self: P) -> Generator[P, None, None]: ...
 
 
 class DBFSPath(_DatabricksPath):

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -137,7 +137,7 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
         # Force all initialisation to go via __init__() irrespective of the (Python-specific) base version.
         return object.__new__(cls)
 
-    def __init__(self, ws: WorkspaceClient, *args: str | bytes | os.PathLike) -> None:  # pylint: disable=super-init-not-called,useless-suppression
+    def __init__(self, ws: WorkspaceClient, *args: str | bytes | os.PathLike) -> None:
         # We deliberately do _not_ call the super initializer because we're taking over complete responsibility for the
         # implementation of the public API.
 
@@ -385,7 +385,7 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
             raise ValueError(msg)
         return self.with_name(stem + suffix)
 
-    def relative_to(self: P, *other: str | bytes | os.PathLike, walk_up: bool = False) -> P:  # pylint: disable=arguments-differ,useless-suppression
+    def relative_to(self: P, *other: str | bytes | os.PathLike, walk_up: bool = False) -> P:
         normalized = self.with_segments(*other)
         if self.anchor != normalized.anchor:
             msg = f"{str(self)!r} and {str(normalized)!r} have different anchors"
@@ -408,7 +408,7 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
             relative_parts = (*walkup_parts, *relative_parts)
         return self.with_segments("", *relative_parts)
 
-    def is_relative_to(self, *other: str | bytes | os.PathLike) -> bool:  # pylint: disable=arguments-differ,useless-suppression
+    def is_relative_to(self, *other: str | bytes | os.PathLike) -> bool:
         normalized = self.with_segments(*other)
         if self.anchor != normalized.anchor:
             return False

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -592,7 +592,7 @@ class DBFSPath(_DatabricksPath):
         if not follow_symlinks:
             raise NotImplementedError("follow_symlinks=False is not supported for DBFS")
         try:
-            self._ws.dbfs.get_status(self.as_posix())
+            self._cached_file_info = self._ws.dbfs.get_status(self.as_posix())
             return True
         except NotFound:
             return False
@@ -741,7 +741,7 @@ class WorkspacePath(_DatabricksPath):
         if not follow_symlinks:
             raise NotImplementedError("follow_symlinks=False is not supported for Databricks Workspace")
         try:
-            self._ws.workspace.get_status(self.as_posix())
+            self._cached_object_info = self._ws.workspace.get_status(self.as_posix())
             return True
         except NotFound:
             return False

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -496,7 +496,10 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
         return pattern_parts
 
     def glob(
-        self: P, pattern: str | bytes | os.PathLike, *, case_sensitive: bool | None = None
+        self: P,
+        pattern: str | bytes | os.PathLike,
+        *,
+        case_sensitive: bool | None = None,
     ) -> Generator[P, None, None]:
         pattern_parts = self._prepare_pattern(pattern)
         if case_sensitive is None:
@@ -505,7 +508,10 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
         yield from selector(self)
 
     def rglob(
-        self: P, pattern: str | bytes | os.PathLike, *, case_sensitive: bool | None = None
+        self: P,
+        pattern: str | bytes | os.PathLike,
+        *,
+        case_sensitive: bool | None = None,
     ) -> Generator[P, None, None]:
         pattern_parts = ("**", *self._prepare_pattern(pattern))
         if case_sensitive is None:

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -513,6 +513,9 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
     def as_uri(self) -> str: ...
 
     @abstractmethod
+    def as_fuse(self) -> Path: ...
+
+    @abstractmethod
     def exists(self, *, follow_symlinks: bool = True) -> bool: ...
 
     @abstractmethod

--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -118,6 +118,7 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
     _flavour = object()
 
     # Public APIs that we don't support.
+    as_uri = _na("as_uri")
     cwd = _na("cwd")
     stat = _na("stat")
     chmod = _na("chmod")
@@ -203,9 +204,6 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
         if part and part[0] == sep:
             return sep, part.lstrip(sep)
         return "", part
-
-    @abstractmethod
-    def as_uri(self) -> str: ...
 
     @abstractmethod
     def as_fuse(self) -> Path: ...
@@ -585,8 +583,6 @@ class DBFSPath(_DatabricksPath):
         path = cls(ws, file_info.path)
         path._cached_file_info = file_info
         return path
-
-    as_uri = _na("as_uri")
 
     def as_fuse(self) -> Path:
         """Return FUSE-mounted path in Databricks Runtime."""

--- a/tests/integration/test_paths.py
+++ b/tests/integration/test_paths.py
@@ -67,6 +67,28 @@ def test_open_text_io(ws, make_random, cls):
 
 
 @pytest.mark.parametrize("cls", DATABRICKS_PATHLIKE)
+def test_unlink(ws, make_random, cls):
+    name = make_random()
+    tmp_dir = cls(ws, f"~/{name}").expanduser()
+    tmp_dir.mkdir()
+    try:
+        # Check unlink() interactions with a file that exists.
+        some_file = tmp_dir / "some-file.txt"
+        some_file.write_text("Some text")
+        assert some_file.exists() and some_file.is_file()
+        some_file.unlink()
+        assert not some_file.exists()
+
+        # And now the interactions with a missing file.
+        missing_file = tmp_dir / "missing-file.txt"
+        missing_file.unlink(missing_ok=True)
+        with pytest.raises(FileNotFoundError):
+            missing_file.unlink(missing_ok=False)
+    finally:
+        tmp_dir.rmdir(recursive=True)
+
+
+@pytest.mark.parametrize("cls", DATABRICKS_PATHLIKE)
 def test_open_binary_io(ws, make_random, cls):
     name = make_random()
     wsp = cls(ws, f"~/{name}")

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -424,8 +424,19 @@ def test_iterdir() -> None:
 def test_exists_when_path_exists() -> None:
     ws = create_autospec(WorkspaceClient)
     workspace_path = WorkspacePath(ws, "/test/path")
-    ws.workspace.get_status.return_value = True
+    ws.workspace.get_status.return_value = ObjectInfo(path="/test/path")
     assert workspace_path.exists()
+
+
+def test_exists_caches_info() -> None:
+    ws = create_autospec(WorkspaceClient)
+    workspace_path = WorkspacePath(ws, "/test/path")
+    ws.workspace.get_status.return_value = ObjectInfo(path="/test/path", object_type=ObjectType.FILE)
+    _ = workspace_path.exists()
+
+    ws.workspace.get_status.reset_mock()
+    _ = workspace_path.is_file()
+    assert not ws.workspace.get_status.called
 
 
 def test_exists_when_path_does_not_exist() -> None:


### PR DESCRIPTION
This PR extends the existing `WorkspacePath` support with a pathlib-like implementation for DBFS paths: `DBFSPath`

Incidental changes include:

 - Type-hinting the implementation and interfaces to assist with code linting.