### PR TITLE
Make hatch a prerequisite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,8 @@ def viz_type(self) -> str:
 ## Local Setup
 
 This section provides a step-by-step guide to set up and start working on the project. These steps will help you set up your project environment and dependencies for efficient development.
-
-To begin, run `make dev` create the default environment and install development dependencies, assuming you've already cloned the github repo.
+Please note that hatch is a prerequisite. You can install hatch using `pip install hatch`.
+To begin, run `make dev` to create the default environment and install development dependencies, assuming you've already cloned the github repo.
 
 ```shell
 make dev

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ clean:
 	rm -fr **/*.pyc
 
 .venv/bin/python:
-	pip install hatch
 	hatch env create
 
 dev: .venv/bin/python


### PR DESCRIPTION
`pip install hatch` sometimes fails depending on local environment
drop the line, and make it a prerequisite, as it is for ucx