### PR TITLE
normalize databricks paths as part of resolving them

### DIFF
--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -520,7 +520,17 @@ class _DatabricksPath(Path, abc.ABC):  # pylint: disable=too-many-public-methods
         if strict and not absolute.exists():
             msg = f"Path does not exist: {self}"
             raise FileNotFoundError(msg)
-        return absolute
+        return absolute._normalize()
+
+    def _normalize(self) -> P:
+        for index, part in enumerate(self._path_parts):
+            if part != '..':
+                continue
+            segments = list(self._path_parts)
+            segments.pop(index)
+            segments.pop(index - 1)
+            return self.with_segments(self.anchor, *segments)._normalize()
+        return self
 
     def absolute(self: P) -> P:
         if self.is_absolute():

--- a/tests/integration/test_paths.py
+++ b/tests/integration/test_paths.py
@@ -191,6 +191,12 @@ def test_replace_file(ws, make_random, cls):
         tmp_dir.rmdir(recursive=True)
 
 
+def test_resolve_is_consistent(ws):
+    path = WorkspacePath(ws, "/a/b/c") / Path("../../d")
+    resolved = path.resolve()
+    assert resolved == WorkspacePath(ws,"/a/d")
+
+
 def test_workspace_as_fuse(ws):
     wsp = WorkspacePath(ws, "/Users/foo/bar/baz")
     assert Path("/Workspace/Users/foo/bar/baz") == wsp.as_fuse()


### PR DESCRIPTION
Path("/a/b/../c").resolve() returns Path("/a/c")
Databricks paths should behave the same, but currently don't.
This PR fixes the issue, which participates in https://github.com/databrickslabs/ucx/issues/2882

Progresses https://github.com/databrickslabs/ucx/issues/2882 