### PR TITLE
Skip dataclassess fields only when `None`

### DIFF
--- a/src/databricks/labs/blueprint/installation.py
+++ b/src/databricks/labs/blueprint/installation.py
@@ -570,7 +570,7 @@ class Installation:
             if origin is typing.ClassVar:
                 continue
             raw = getattr(inst, field)
-            if not raw:
+            if raw is None:
                 continue
             value, ok = self._marshal(hint, [*path, field], raw)
             if not ok:


### PR DESCRIPTION
Skip dataclassess fields only when `None` to allow to write empty lists, strings or zeros.

Resolves #179