### PR TITLE
Ensure the names of logger levels are consistent

### DIFF
--- a/src/databricks/labs/blueprint/logger.py
+++ b/src/databricks/labs/blueprint/logger.py
@@ -32,12 +32,11 @@ class NiceFormatter(logging.Formatter):
         """
         super().__init__(fmt="%(asctime)s %(levelname)s [%(name)s] %(message)s", datefmt="%H:%M")
         self._levels = {
-            logging.NOTSET: self._bold("TRACE"),
-            logging.DEBUG: self._bold(f"{self.CYAN}DEBUG"),
-            logging.INFO: self._bold(f"{self.GREEN} INFO"),
-            logging.WARNING: self._bold(f"{self.YELLOW} WARN"),
-            logging.ERROR: self._bold(f"{self.RED}ERROR"),
-            logging.CRITICAL: self._bold(f"{self.MAGENTA}FATAL"),
+            logging.DEBUG: self._bold(f"{self.CYAN}   DEBUG"),
+            logging.INFO: self._bold(f"{self.GREEN}    INFO"),
+            logging.WARNING: self._bold(f"{self.YELLOW} WARNING"),
+            logging.ERROR: self._bold(f"{self.RED}   ERROR"),
+            logging.CRITICAL: self._bold(f"{self.MAGENTA}CRITICAL"),
         }
         # show colors in runtime, github actions, and while debugging
         self.colors = stream.isatty() if probe_tty else True

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -271,20 +271,8 @@ def test_formatter_format_log_level(level: int, use_colors: bool) -> None:
     formatted = formatter.format(record)
     stripped = _strip_sgr_sequences(formatted) if use_colors else formatted
 
-    # Can't mark combinations of parameters for xfail, so we simulate it here.
-    expected_failure = use_colors and level in (logging.WARNING, logging.CRITICAL)
-    try:
-        # H:M:S LEVEL [logger_name] message
-        assert f" {logging.getLevelName(level)} " in stripped
-        if expected_failure:
-            msg = (
-                f"Unexpected success: colorized log-level for {logging.getLevelName(level)} is thought to be incorrect."
-            )
-            pytest.fail(msg)
-    except AssertionError:
-        if not expected_failure:
-            raise
-        pytest.xfail(f"Colorized log-level formatting for {logging.getLevelName(level)} is known to be incorrect.")
+    # H:M:S LEVEL [logger_name] message
+    assert f" {logging.getLevelName(level)} " in stripped
 
 
 # Logger names, and their abbreviated forms.


### PR DESCRIPTION
This PR updates the names we use for the `WARNING` and `CRITICAL` log-levels when produced colorised logs. Prior to this PR:

 - When not-colorised, we used the conventional `WARNING` and `CRITICAL` names.
 - When colorised, we used `WARN` and `FATAL` instead.

Although the latter is more compact, it's more important to: a) be consistent; b) conform to the norms of the Python ecosystem and use the conventional names for the logging levels.

This PR is stacked on top of #232 and resolves #229.