### PR TITLE
Consistent exception formatting in logs

### DIFF
--- a/src/databricks/labs/blueprint/logger.py
+++ b/src/databricks/labs/blueprint/logger.py
@@ -60,9 +60,11 @@ class NiceFormatter(logging.Formatter):
         if record.exc_info and not record.exc_text:
             record.exc_text = self.formatException(record.exc_info)
         if record.exc_text:
-            msg += ": " + record.exc_text
+            if not msg.endswith("\n"):
+                msg += "\n"
+            msg += record.exc_text
         if record.stack_info:
-            if msg[-1:] != "\n":
+            if not msg.endswith("\n"):
                 msg += "\n"
             msg += self.formatStack(record.stack_info)
 

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -107,7 +107,7 @@ def test_installed_logger_logging(logging_system) -> None:
     assert "This is a debug message" in output
     assert "This is an info message" in output
     assert "This is a warning message" in output
-    assert "This is an error message: KeyError: 123" in output
+    assert "This is an error message\nKeyError: 123" in output
     assert "This is a critical message" in output
 
 
@@ -357,19 +357,7 @@ def test_formatter_format_colorized_thread_name() -> None:
     assert f"][{thread_record.threadName}] " in _strip_sgr_sequences(formatter.format(thread_record))
 
 
-@pytest.mark.parametrize(
-    "use_colors",
-    (
-        pytest.param(
-            True,
-            marks=pytest.mark.xfail(
-                reason="Colorized exception formatting is inconsistent with system logging.", strict=True
-            ),
-        ),
-        False,
-    ),
-    ids=("with_colors", "without_colors"),
-)
+@pytest.mark.parametrize("use_colors", (True, False), ids=("with_colors", "without_colors"))
 def test_formatter_format_exception(use_colors: bool) -> None:
     """The colorized formatter includes the thread name if non-main."""
     formatter = NiceFormatter()


### PR DESCRIPTION
This PR updates the format of logs to be consistent when exception information is included, irrespective of whether the logs are colorised or not. Prior to this PR, colorised logs were formatted slightly differently to the Python norms:
```
16:06:10 ERROR [d.l.module] An error occurred: Traceback (most recent call last):
  File "/path/to/file.py", line 410, in some_function
    raise RuntimeError("Test exception.")
RuntimeError: Test exception.
```
(Note that the traceback starts on the line of the error.)

This PR updates this to be:
```
16:08:18 ERROR [d.l.module] An error occurred
Traceback (most recent call last):
  File "/path/to/file.py", line 410, in some_function
    raise RuntimeError("Test exception.")
RuntimeError: Test exception.
```

This PR is stacked on top of #232.