### PR TITLE
Ensure that App logger emits `DEBUG` events if the CLI is invoked with `--debug`

### DIFF
--- a/src/databricks/labs/blueprint/entrypoint.py
+++ b/src/databricks/labs/blueprint/entrypoint.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from databricks.labs.blueprint.logger import install_logger
 
 
-def get_logger(__file: str):
+def get_logger(__file: str, *, manager: logging.Manager = logging.Logger.manager) -> logging.Logger:
     """Used as `get_logger(__file__)` to return a relevant logger for a file"""
     project_root = find_project_root(__file).absolute()
     entrypoint = Path(__file).absolute()
@@ -21,12 +21,10 @@ def get_logger(__file: str):
     relative = relative.removesuffix(".py")
     module_name = relative.replace(os.sep, ".")
 
-    logger = logging.getLogger(module_name)
+    logger = manager.getLogger(module_name)
 
-    level = "INFO"
     if is_in_debug():
-        level = "DEBUG"
-    logger.setLevel(level)
+        logger.setLevel(logging.DEBUG)
 
     return logger
 

--- a/tests/unit/test_entrypoint.py
+++ b/tests/unit/test_entrypoint.py
@@ -1,11 +1,14 @@
 import inspect
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
+import databricks.labs.blueprint.entrypoint as entrypoint
 from databricks.labs.blueprint.entrypoint import (
     find_project_root,
+    get_logger,
     relative_paths,
     run_main,
 )
@@ -40,3 +43,40 @@ def test_run_main():
     main = MagicMock()
     run_main(main)
     main.assert_called_once()
+
+
+def test_get_logger_name() -> None:
+    """Ensure the logger name is set to something module-like, even if the file is a script/path."""
+    # File is something like /path/to/blueprint/tests/unit/test_entrypoint.py
+    logger = get_logger(__file__)
+
+    assert logger.name == "tests.unit.test_entrypoint"
+
+
+@pytest.fixture
+def log_manager() -> logging.Manager:
+    """Logging manager, independent of the system logging."""
+    root = logging.RootLogger(logging.WARNING)
+    return logging.Manager(root)
+
+
+def test_get_logger_when_in_debug(monkeypatch, log_manager: logging.Manager) -> None:
+    """When in debug mode, the logger is hardcoded to DEBUG level."""
+    monkeypatch.setattr(entrypoint, "is_in_debug", lambda: True)
+
+    # Ensure we don't get a cached logger that has already been configured to a level.
+    logger = get_logger(__file__, manager=log_manager)
+
+    assert logger.level == logging.DEBUG
+    assert logger.propagate is True
+
+
+def test_get_logger_when_not_in_debug(monkeypatch, log_manager: logging.Manager) -> None:
+    """When in not in debug mode, the logger should simply propagate to the parent."""
+    monkeypatch.setattr(entrypoint, "is_in_debug", lambda: False)
+
+    # Ensure we don't get a cached logger that has already been configured to a level.
+    logger = get_logger(__file__, manager=log_manager)
+
+    assert logger.level == logging.NOTSET
+    assert logger.propagate is True


### PR DESCRIPTION
This PR resolves an issue whereby `--debug` being used when launching CLI applications did not result in `DEBUG` logging, as described on #228.

The issue is that although the `DEBUG` log-level is set on a parent logger, the "application" logger (a child) was being set to `INFO`, unless running within an IDE. This meant that most logs from within the application were suppressed.

Prior to this PR the hierarchy typically looked like this when `--debug` was provided:

| Logger                         | Level     | Effective Level |
|--------------------------------|-----------|-----------------|
| _root_                         | `WARNING` | `WARNING`       |
| `databricks`                   | `DEBUG`   | `DEBUG`         |
| `databricks.labs.app`          | `INFO`    | `INFO`          |
| `databricks.labs.app.module.a` | _not set_ | `INFO`          |
| `databricks.labs.app.module.b` | _not set_ | `INFO`          |

With this PR it becomes this:

| Logger                         | Level     | Effective Level |
|--------------------------------|-----------|-----------------|
| _root_                         | `WARNING` | `WARNING`       |
| `databricks`                   | `DEBUG`   | `DEBUG`         |
| `databricks.labs.app`          | _not set_ | `DEBUG`         |
| `databricks.labs.app.module.a` | _not set_ | `DEBUG`         |
| `databricks.labs.app.module.b` | _not set_ | `DEBUG`         |


### Linked Issues

Resolves: #228, databrickslabs/remorph#1494.

### Tests

 - [X] Added unit tests
 - [X] Manually tested with `remorph`
 - [x] Manually tested with `ucx`

Sample remorph logs:
```
17:26:41  INFO [d.l.remorph.install] Configuring remorph `transpile`.
17:26:41 DEBUG [d.l.blueprint.installation] Loading TranspileConfig from config.yml
```