### PR TITLE
Logging context

### DIFF
--- a/src/databricks/labs/blueprint/_logging_context.py
+++ b/src/databricks/labs/blueprint/_logging_context.py
@@ -1,0 +1,175 @@
+"""internall plumbing for passing logging context (dict) to logger instances"""
+
+import dataclasses
+import inspect
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import partial, wraps
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Annotated, Any, TypeVar, get_origin
+
+AnyType = TypeVar("AnyType")
+
+if TYPE_CHECKING:
+    SkipLogging = Annotated[AnyType, ...]  # SkipLogging[list[str]] will be treated by type checkers as list[str]
+else:
+
+    @dataclasses.dataclass(slots=True)
+    class SkipLogging:
+        """`@logging_context_params` will ignore parameters annotated with this class."""
+
+        def __class_getitem__(cls, item: Any) -> Any:
+            return Annotated[item, SkipLogging()]
+
+
+_CTX: ContextVar = ContextVar("ctx", default={})
+
+
+def _params_str(d):
+    return ", ".join(f"{k}={v!r}" for k, v in d.items())
+
+
+def _get_skip_logging_param_names(sig: inspect.Signature):
+    """Generates list of parameters names having SkipLogging annotation"""
+    for name, param in sig.parameters.items():
+        a = param.annotation
+
+        # only consider annotation
+        if not a or get_origin(a) is not Annotated:
+            continue
+
+        # there can be many annotations for each param
+        for m in a.__metadata__:
+            if isinstance(m, SkipLogging):
+                yield name
+
+
+def _skip_dict_key(d: dict, keys_to_skip: set):
+    return {k: v for k, v in d.items() if k not in keys_to_skip}
+
+
+def current_context():
+    """Returns dictionary of current context set via `with loggin_context(...)` context manager or `@logging_context_params` decorator
+
+    Example:
+    current_context()
+    >>> {'foo': 'bar', 'a': 2}
+
+    """
+    return _CTX.get()
+
+
+def current_context_repr():
+    """Returns repr like "key1=val1, key2=val2" string representation of current_context(), or "" in case context is empty"""
+    return _params_str(current_context())
+
+
+@contextmanager
+def logging_context(**kwds):
+    """Context manager adding keywords to current loging context. Thread and async safe.
+
+    Example:
+    with logging_context(foo="bar", a=2):
+        logger.info("hello")
+    >>> 2025-06-06 07:15:09,329 - __main__ - INFO - hello (foo='bar', a=2)
+    """
+    # Get the current context and update it with new keywords
+    current_ctx = _CTX.get()
+    new_ctx = {**current_ctx, **kwds}
+    token = _CTX.set(MappingProxyType(new_ctx))
+    try:
+        yield _CTX.get()
+    except Exception as e:
+        # python 3.11+: https://docs.python.org/3.11/tutorial/errors.html#enriching-exceptions-with-notes
+        # https://peps.python.org/pep-0678/
+        if hasattr(e, "add_note"):
+            # __notes__ list[str] is only defined if notes were added, otherwise is not there
+            # we only want to add note if there was no note before, otherwise chaining context cause sproblems
+            if not getattr(e, "__notes__", None):
+                e.add_note(f"Context: {_params_str(current_context())}")
+
+        raise
+    finally:
+        _CTX.reset(token)
+
+
+def logging_context_params(func=None, **extra_context):
+    """Decorator that automatically adds all the function parameters to current logging context.
+
+    Any passed keyward arguments in will be added to the context. Function parameters take precendnce over the extra keywords in case the names would overlap.
+
+    Parameters annotated with `SkipLogging` will be ignored from being added to the context.
+
+    Example:
+
+    @logging_context_params(foo="bar")
+    def do_math(a: int, b: SkipLogging[int]):
+        r = pow(a, b)
+        logger.info(f"result of {a}**{b} is {r}")
+        return r
+
+    >>> 2025-06-06 07:15:09,329 - __main__ - INFO - result of 2**8 is 256 (foo='bar', a=2)
+
+    Note:
+    - `a` parameter will be logged, type annotation is optional
+    - `b` parameter wont be logged because is it is annotated with `SkipLogging`
+    - `foo` parameter will be logged because it is passed as extra context to the decorator
+
+    """
+
+    if func is None:
+        p = partial(logging_context_params, **extra_context)
+        return p
+
+    # will use function's singature to bind positional params to name of the param
+    sig = inspect.signature(func)
+    skip_params = set(_get_skip_logging_param_names(sig))
+
+    @wraps(func)
+    def wrapper(*args, **kwds):
+        # only bind if there are positional args
+        # extra context has lower priority than any of the args
+        # skip_params is used to filter out parameters that are annotated with SkipLogging
+
+        if args:
+            b = sig.bind(*args, **kwds)
+            ctx_data = {**extra_context, **_skip_dict_key(b.arguments, skip_params)}
+        else:
+            ctx_data = {**extra_context, **_skip_dict_key(kwds, skip_params)}
+
+        with logging_context(**ctx_data):
+            return func(*args, **kwds)
+
+    return wrapper
+
+
+class LoggingContextFilter(logging.Filter):
+    """Adds curent_context() to the log record."""
+
+    def filter(self, record):
+        ctx = current_context()
+        record.context = f"({_params_str(ctx)})" if ctx else ""
+        return True
+
+
+class LoggingThreadPoolExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor drop in replacement that will apply current loging context to all new started threads."""
+
+    def __init__(self, max_workers=None, thread_name_prefix="", initializer=None, initargs=()):
+        self.__current_context = current_context()
+        self.__wrapped_initializer = initializer
+
+        super().__init__(
+            max_workers=max_workers,
+            thread_name_prefix=thread_name_prefix,
+            initializer=self._logging_context_init,
+            initargs=initargs,
+        )
+
+    def _logging_context_init(self, *args):
+        global _CTX
+        _CTX.set(self.__current_context)
+        if self.__wrapped_initializer:
+            self.__wrapped_initializer(*args)

--- a/src/databricks/labs/blueprint/_logging_context.py
+++ b/src/databricks/labs/blueprint/_logging_context.py
@@ -44,7 +44,7 @@ def _get_skip_logging_param_names(sig: inspect.Signature):
             try:
                 if meta and isinstance(meta, SkipLogging):
                     yield name
-            except Exception:
+            except Exception: # pylint: disable=broad-exception-caught
                 # in case `meta` is not comptitble with isinstance, just ignore it and move to next meta
                 pass
 

--- a/src/databricks/labs/blueprint/logger.py
+++ b/src/databricks/labs/blueprint/logger.py
@@ -4,7 +4,23 @@ import logging
 import sys
 from typing import TextIO
 
-from ._logging_context import LoggingContextFilter, current_context_repr
+from ._logging_context import (
+    LoggingContextFilter,
+    SkipLogging,
+    current_context,
+    current_context_repr,
+    logging_context,
+    logging_context_params,
+)
+
+__all__ = [
+    "NiceFormatter",
+    "install_logger",
+    "current_context",
+    "SkipLogging",
+    "logging_context_params",
+    "logging_context",
+]
 
 
 class NiceFormatter(logging.Formatter):

--- a/src/databricks/labs/blueprint/parallel.py
+++ b/src/databricks/labs/blueprint/parallel.py
@@ -10,6 +10,7 @@ import threading
 from collections.abc import Callable, Collection, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Generic, TypeVar
+from ._logging_context import LoggingThreadPoolExecutor
 
 MIN_THREADS = 8
 
@@ -51,12 +52,12 @@ class Threads(Generic[Result]):
         return cls(name, tasks, num_threads=num_threads)._run()
 
     @classmethod
-    def strict(cls, name: str, tasks: Sequence[Task[Result]]) -> Collection[Result]:
+    def strict(cls, name: str, tasks: Sequence[Task[Result]], num_threads: int | None = None) -> Collection[Result]:
         """Run tasks in parallel and raise ManyError if any task fails"""
         # this dunder variable is hiding this method from tracebacks, making it cleaner
         # for the user to see the actual error without too much noise.
         __tracebackhide__ = True  # pylint: disable=unused-variable
-        collected, errs = cls.gather(name, tasks)
+        collected, errs = cls.gather(name, tasks, num_threads)
         if errs:
             if len(errs) == 1:
                 raise errs[0]
@@ -104,7 +105,7 @@ class Threads(Generic[Result]):
     def _execute(self):
         """Run tasks in parallel and return futures"""
         thread_name_prefix = re.sub(r"\W+", "_", self._name)
-        with ThreadPoolExecutor(self._num_threads, thread_name_prefix) as pool:
+        with LoggingThreadPoolExecutor(self._num_threads, thread_name_prefix) as pool:
             futures = []
             for task in self._tasks:
                 if task is None:

--- a/tests/unit/test_logger_context.py
+++ b/tests/unit/test_logger_context.py
@@ -1,0 +1,197 @@
+import logging
+
+from databricks.labs.blueprint._logging_context import LoggingThreadPoolExecutor
+from databricks.labs.blueprint.logger import (
+    SkipLogging,
+    current_context,
+    logging_context,
+    logging_context_params,
+)
+
+
+def test_nested_logger_context():
+    logger = logging.getLogger(__name__)
+
+    ctx0 = current_context()
+    logger.info("before entering context")
+
+    with logging_context(user="Alice", action="read") as ctx1:
+        logger.info("inside of first context")
+        assert ctx1 == {"user": "Alice", "action": "read"}
+
+        with logging_context(action="write") as ctx2:
+            logger.info("inner context")
+            assert ctx2 == {"user": "Alice", "action": "write"}
+
+        logger.info("still inside first")
+        assert current_context() == ctx1
+
+    logger.info("after exiting context")
+    assert current_context() == ctx0
+
+    with logging_context(user="Bob", action="write") as ctx2:
+        logger.info("inside of second context")
+        assert ctx2 == {"user": "Bob", "action": "write"}
+
+
+def test_exception_with_notest_flat():
+    logger = logging.getLogger(__name__)
+
+    try:
+        with logging_context(
+            user="Alice",
+            action="read",
+        ):
+            logger.info("inside of first context")
+            with logging_context(top_secret="47"):
+                1 / 0
+    except Exception as e:
+        logger.exception(f"Exception! {e}")
+        assert e.__notes__ == ["Context: user='Alice', action='read', top_secret='47'"]
+        assert str(e) == "division by zero"
+
+
+def test_exception_with_notest_nested():
+    logger = logging.getLogger(__name__)
+    logger.info("before entering context")
+
+    try:
+        with logging_context(file="foo.txt"):
+            with logging_context(
+                user="Alice",
+                action="read",
+            ):
+                logger.info("inside of first context")
+                1 / 0
+    except Exception as e:
+        logger.exception(f"Exception! {e}")
+        logger.error(f"Error! {e}")
+        assert e.__notes__ == ["Context: file='foo.txt', user='Alice', action='read'"]
+        assert str(e) == "division by zero"
+
+
+def test_logging_function_params_empty_deco_call():
+    logger = logging.getLogger(__name__)
+
+    @logging_context_params()
+    def do_math_verbose_test(a: int, b):
+        r = pow(a, b)
+        logger.info(f"result of {a}**{b} is {r}")
+        assert current_context() == {"a": a, "b": b}
+        return r
+
+    assert current_context() == {}
+    do_math_verbose_test(2, b=8)
+    assert current_context() == {}
+    do_math_verbose_test(2, b=7)
+    assert current_context() == {}
+
+
+def test_logging_function_params_no_call():
+    logger = logging.getLogger(__name__)
+
+    @logging_context_params
+    def do_math_verbose_test(a: int, b):
+        r = pow(a, b)
+        logger.info(f"result of {a}**{b} is {r}")
+        assert current_context() == {"a": a, "b": b}
+        return r
+
+    assert current_context() == {}
+    do_math_verbose_test(2, b=8)
+    assert current_context() == {}
+    do_math_verbose_test(2, b=7)
+    assert current_context() == {}
+
+
+def test_logging_function_skip_loggingl():
+    logger = logging.getLogger(__name__)
+
+    @logging_context_params
+    def do_math_verbose_test(a: SkipLogging[float], b):
+        r = pow(a, b)
+        logger.info(f"result of {a}**{b} is {r}")
+        assert current_context() == {"b": b}
+        return r
+
+    assert current_context() == {}
+    do_math_verbose_test(2, b=8)
+    assert current_context() == {}
+    do_math_verbose_test(2, b=7)
+    assert current_context() == {}
+
+
+def test_logging_function_params_shadow_deco_call():
+    logger = logging.getLogger(__name__)
+
+    @logging_context_params(a="bar")
+    def do_math_verbose_test(a: int, b):
+        r = pow(a, b)
+        logger.info(f"result of {a}**{b} is {r}")
+        assert current_context() == {"a": a, "b": b}
+        return r
+
+    assert current_context() == {}
+    do_math_verbose_test(2, b=8)
+    assert current_context() == {}
+    do_math_verbose_test(2, b=7)
+    assert current_context() == {}
+
+
+def test_logging_function_params_non_shadow_deco_call():
+    logger = logging.getLogger(__name__)
+
+    @logging_context_params(foo="bar")
+    def do_math_verbose_test(a: int, b):
+        r = pow(a, b)
+        logger.info(f"result of {a}**{b} is {r}")
+        assert current_context() == {"foo": "bar", "a": a, "b": b}
+        return r
+
+    assert current_context() == {}
+    do_math_verbose_test(2, b=8)
+    assert current_context() == {}
+    do_math_verbose_test(2, b=7)
+    assert current_context() == {}
+
+
+def test_logging_function_params_multiple_contexts():
+    logger = logging.getLogger(__name__)
+
+    @logging_context_params(foo="bar")
+    def do_math_verbose_test(a: int, b):
+        r = pow(a, b)
+        logger.info(f"result of {a}**{b} is {r}")
+        assert current_context() == {"foo": "bar", "a": a, "b": b, "x": "6"}
+        return r
+
+    with logging_context(x="6"):
+        do_math_verbose_test(2, b=8)
+
+
+def test_logging_thread_pool():
+    logger = logging.getLogger(__name__)
+
+    @logging_context_params(foo="bar")
+    def do_math_verbose(a, b: int):
+        r = pow(a, b)
+        logger.info(f"result of {a}**{b} is {r}")
+        assert current_context() == {"foo": "bar", "a": a, "b": b, "user": "Alice"}
+        return r
+
+    def do_math_verbose_without_context(a, b: int):
+        r = pow(a, b)
+        logger.info(f"result of {a}**{b} is {r}")
+        assert current_context() == {"foo": "bar" if a == 2 else "zar", "a": a, "b": b, "user": "Alice"}
+        return r
+
+    with logging_context(user="Alice"):
+        futures = []
+        with LoggingThreadPoolExecutor(max_workers=1) as executor:
+            futures.append(executor.submit(do_math_verbose, 2, 2))
+            futures.append(executor.submit(do_math_verbose, 2, 6))
+            futures.append(executor.submit(logging_context_params(foo="zar")(do_math_verbose_without_context), 3, 8))
+            futures.append(executor.submit(logging_context_params(foo="zar")(do_math_verbose_without_context), 3, 12))
+
+            for f in futures:
+                f.result()


### PR DESCRIPTION
Add support of passing context vars into logger and attaching them to Exceptions as notes (python 3.11 feature). This enabled clean notification about what is the context under which given error occured.

State:
- code works & test pass
- mypy complains about one of the Annotations... need to fix that for sake of static checking
- docs ... need to write them