### PR TITLE
Fix configuration file unmarshalling of JSON floating-point values

### DIFF
--- a/src/databricks/labs/blueprint/installation.py
+++ b/src/databricks/labs/blueprint/installation.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 JsonList: TypeAlias = List["JsonValue"]  # pylint: disable=deprecated-typing-alias
 JsonObject: TypeAlias = Dict[str, "JsonValue"]  # pylint: disable=deprecated-typing-alias
 RootJsonValue: TypeAlias = JsonObject | JsonList
-JsonValue: TypeAlias = None | bool | int | float | str | RootJsonValue
+JsonValue: TypeAlias = None | bool | float | int | str | RootJsonValue
 
 
 __all__ = ["Installation", "MockInstallation", "IllegalState", "NotInstalled", "SerdeError", "JsonValue"]

--- a/src/databricks/labs/blueprint/installation.py
+++ b/src/databricks/labs/blueprint/installation.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 JsonList: TypeAlias = List["JsonValue"]  # pylint: disable=deprecated-typing-alias
 JsonObject: TypeAlias = Dict[str, "JsonValue"]  # pylint: disable=deprecated-typing-alias
 RootJsonValue: TypeAlias = JsonObject | JsonList
-JsonValue: TypeAlias = None | bool | float | int | str | RootJsonValue
+JsonValue: TypeAlias = None | bool | int | float | str | RootJsonValue
 
 
 __all__ = ["Installation", "MockInstallation", "IllegalState", "NotInstalled", "SerdeError", "JsonValue"]
@@ -831,11 +831,15 @@ class Installation:
         # No coercion necessary.
         if isinstance(inst, type_ref):
             return inst
+
         # Only attempt coercion between primitive types.
         if type(inst) not in cls._PRIMITIVES:
             msg = f"{'.'.join(path)}: Expected {type_ref.__name__}, got: {inst}"
             raise SerdeError(msg)
-        # Special case for strings to bool
+
+        # Some special cases:
+        #  - str -> bool: only accept "true" or "false" (case-insensitive).
+        #  - float -> int: refuse to truncate
         if type_ref == bool:
             if isinstance(inst, str):
                 if inst.lower() == "true":
@@ -844,6 +848,10 @@ class Installation:
                     return False
             msg = f"{'.'.join(path)}: Expected bool, got: {inst}"
             raise SerdeError(msg)
+        if type_ref == int and isinstance(inst, float):
+            msg = f"{'.'.join(path)}: Expected int, got float: {inst}"
+            raise SerdeError(msg)
+
         # Everything else.
         try:
             converted = type_ref(inst)

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -514,7 +514,7 @@ def test_generic_dict_json_value() -> None:
 
     installation = MockInstallation()
 
-    json_like: dict[str, JsonValue] = {"a": ["x", "y"], "b": [], "c": 3, "d": True, "e": {"a": "b"}}
+    json_like: dict[str, JsonValue] = {"a": ["x", "y"], "b": [], "c": 3, "d": True, "e": {"a": "b"}, "f": 0.1}
     saved = SampleClass(field=json_like)
     installation.save(saved, filename="backups/SampleClass.json")
     loaded = installation.load(SampleClass, filename="backups/SampleClass.json")
@@ -581,6 +581,7 @@ def test_generic_list_json() -> None:
         3,
         True,
         {"a": "b"},
+        0.1,
     ]
     saved = SampleClass(field=json_like)
     installation.save(saved, filename="backups/SampleClass.json")

--- a/tests/unit/test_installation.py
+++ b/tests/unit/test_installation.py
@@ -468,6 +468,7 @@ def test_generic_dict_str() -> None:
     saved = SampleClass(field={"a": "b", "b": "c"})
     installation.save(saved, filename="backups/SampleClass.json")
     loaded = installation.load(SampleClass, filename="backups/SampleClass.json")
+    assert isinstance(loaded.field["a"], str)
     assert loaded == saved
 
 
@@ -480,6 +481,7 @@ def test_generic_dict_int() -> None:
     saved = SampleClass(field={"a": 1, "b": 1})
     installation.save(saved, filename="backups/SampleClass.json")
     loaded = installation.load(SampleClass, filename="backups/SampleClass.json")
+    assert isinstance(loaded.field["a"], int)
     assert loaded == saved
 
 
@@ -492,6 +494,7 @@ def test_generic_dict_float() -> None:
     saved = SampleClass(field={"a": 1.1, "b": 1.2})
     installation.save(saved, filename="backups/SampleClass.json")
     loaded = installation.load(SampleClass, filename="backups/SampleClass.json")
+    assert isinstance(loaded.field["a"], float)
     assert loaded == saved
 
 
@@ -518,6 +521,8 @@ def test_generic_dict_json_value() -> None:
     saved = SampleClass(field=json_like)
     installation.save(saved, filename="backups/SampleClass.json")
     loaded = installation.load(SampleClass, filename="backups/SampleClass.json")
+    assert isinstance(loaded.field["c"], int)
+    assert isinstance(loaded.field["f"], float)
     assert loaded == saved
 
 


### PR DESCRIPTION
This PR fixes unmarshalling of `JsonValue` fields if they contain floating point values; prior to this PR they were incorrectly unmarshalled as integers, truncating precision.

The reason for this error is that unmarshalling is somewhat forgiving with coercion allowed between primitives: if the target is a string, boolean/int/float will be converted to a string. Previous this allowed `int(float_value)` to succeed; this PR blocks that specifically, and unit tests have been updated to ensure the values being produced are of the correct type.
