### PR TITLE
Sniff encoding properly in XML files with a standalone directive

### DIFF
--- a/src/databricks/labs/blueprint/paths.py
+++ b/src/databricks/labs/blueprint/paths.py
@@ -1060,7 +1060,11 @@ _XML_ENCODING_SNIFF_LIMIT = 1024
 """The maximum number of bytes to read from the start of a file when sniffing for a potential XML encoding."""
 _XML_DECLARATION_REGEX = re.compile(
     # Not perfect, but matches valid XML declarations. (Plus some invalid ones.)
-    r'^<\?xml\s+version\s*=\s*["\'][0-9.]*["\'](:?\s+encoding\s*=\s*["\'](?P<encoding>[^"\']+)["\'])?\s*\?>',
+    r"^<\?xml"
+    r'\s+version\s*=\s*["\'][0-9.]*["\']'
+    r'(:?\s+encoding\s*=\s*["\'](?P<encoding>[^"\']+)["\'])?'
+    r'(:?\s+standalone\s*=\s*["\'](:?yes|no)["\'])?'
+    r"\s*\?>",
 )
 
 

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1089,7 +1089,7 @@ def test_read_xml_file_with_encoding_declaration(tmp_path: Path, encoding: str) 
         (codecs.BOM_UTF32_BE, "utf-32-be"),
     ),
 )
-def test_read_xml_file_with_com(tmp_path: Path, bom: bytes, encoding: str) -> None:
+def test_read_xml_file_with_bom(tmp_path: Path, bom: bytes, encoding: str) -> None:
     """Verify that we can read text files that include a BOM prefix."""
     path = tmp_path / "file.xml"
     example = "<?xml version='1.1'?>\n<root>[Something fanc\u00fd]</root>"

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1100,6 +1100,27 @@ def test_read_xml_file_with_bom(tmp_path: Path, bom: bytes, encoding: str) -> No
     assert text == example
 
 
+@pytest.mark.parametrize("is_standalone", [True, False])
+def test_read_xml_file_standalone(tmp_path: Path, is_standalone: bool) -> None:
+    """Verify that we can read the encoding directive from a file with an XML standalone declaration."""
+    path = tmp_path / "file.xml"
+    standalone_value = "yes" if is_standalone else "no"
+    # Use an encoding that can't be detected any other way than via the XML declaration.
+    example = (
+        f"<?xml version='1.0'\n"
+        f"      encoding='Windows-1252'\n"
+        f"      standalone='{standalone_value}'?>\n"
+        f"<root>\n"
+        f"  <!-- Sensitive chàráçters -->\n"
+        f"</root>\n"
+    )
+    path.write_text(example, encoding="Windows-1252")
+
+    text = read_text(path, detect_xml=True)
+
+    assert text == example
+
+
 def test_read_xml_file_default_utf8(tmp_path: Path, monkeypatch) -> None:
     """Verify that XML files without a BOM or encoding declaration are read as UTF-8."""
     path = tmp_path / "file.xml"


### PR DESCRIPTION
This PR updates the code that detects the encoding of XML files so that it correctly detects the `encoding=` attribute if there is also a `standalone=` directive. Previously we only supported XML directives of the form:

```xml
<?xml version="1.x" encoding="xxx"?>
```

However the XML declaration may also contain a `standalone=` attribute. If present we previously failed to detect the encoding attribute, but now we also support XML directives of the form:
```xml
<?xml version="1.x" encoding="xxx" standalone="yes"?>
```