### PR TITLE
Improve `Prompt` type hints

### DIFF
--- a/src/databricks/labs/blueprint/tui.py
+++ b/src/databricks/labs/blueprint/tui.py
@@ -5,24 +5,27 @@ from __future__ import annotations
 import getpass
 import logging
 import re
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Callable, Mapping, Sequence
+from typing import TypeVar
 
 logger = logging.getLogger(__name__)
+
+
+T = TypeVar("T")
 
 
 class Prompts:
     """`input()` builtin on steroids"""
 
-    def multiple_choice_from_dict(self, item_prompt: str, choices: dict[str, Any]) -> list[Any]:
-        """Use to select multiple items from dictionary
+    def multiple_choice_from_dict(self, item_prompt: str, choices: Mapping[str, T]) -> Sequence[T]:
+        """Use to select multiple items from a mapping.
 
         :param item_prompt: str:
-        :param choices: dict[str, Any]:
+        :param choices: Mapping[str, T]:
 
         """
-        selected: list[Any] = []
-        dropdown = {"[DONE]": "done"} | choices
+        selected: list[T] = []
+        dropdown = {"[DONE]": "done", **choices}
         while True:
             key = self.choice(item_prompt, list(dropdown.keys()))
             if key == "[DONE]":
@@ -34,11 +37,11 @@ class Prompts:
                 break
         return selected
 
-    def choice_from_dict(self, text: str, choices: dict[str, Any], *, sort: bool = True) -> Any:
+    def choice_from_dict(self, text: str, choices: Mapping[str, T], *, sort: bool = True) -> T:
         """Use to select a value from the dictionary by showing users sorted dictionary keys
 
         :param text: str:
-        :param choices: dict[str,Any]:
+        :param choices: Mapping[str,T]:
         :param *:
         :param sort: bool:  (Default value = True)
 
@@ -46,17 +49,18 @@ class Prompts:
         key = self.choice(text, list(choices.keys()), sort=sort)
         return choices[key]
 
-    def choice(self, text: str, choices: list[Any], *, max_attempts: int = 10, sort: bool = True) -> str:
+    def choice(self, text: str, choices: Sequence[str], *, max_attempts: int = 10, sort: bool = True) -> str:
         """Use to select a value from a list
 
         :param text: str:
-        :param choices: list[Any]:
+        :param choices: Sequence[str]:
         :param *:
         :param max_attempts: int:  (Default value = 10)
         :param sort: bool:  (Default value = True)
 
         """
         if sort:
+            # This forces our choices argument to be a sequence of strings.
             choices = sorted(choices, key=str.casefold)
         numbered = "\n".join(f"\033[1m[{i}]\033[0m \033[36m{v}\033[0m" for i, v in enumerate(choices))
         prompt = f"\033[1m{text}\033[0m\n{numbered}\nEnter a number between 0 and {len(choices) - 1}"
@@ -71,7 +75,7 @@ class Prompts:
         msg = f"cannot get answer within {max_attempts} attempt"
         raise ValueError(msg)
 
-    def confirm(self, text: str, *, max_attempts: int = 10):
+    def confirm(self, text: str, *, max_attempts: int = 10) -> bool:
         """Use to guard any optional or destructive actions of your app
 
         :param text: str:
@@ -147,7 +151,7 @@ class Prompts:
 class MockPrompts(Prompts):
     """Testing utility for prompts"""
 
-    def __init__(self, patterns_to_answers: dict[str, str]):
+    def __init__(self, patterns_to_answers: Mapping[str, str]):
         patterns = [(re.compile(k), v) for k, v in patterns_to_answers.items()]
         self._questions_to_answers = sorted(patterns, key=lambda _: len(_[0].pattern), reverse=True)
 
@@ -161,7 +165,7 @@ class MockPrompts(Prompts):
             return answer
         raise ValueError(f"not mocked: {text}")
 
-    def extend(self, patterns_to_answers: dict[str, str]) -> MockPrompts:
+    def extend(self, patterns_to_answers: Mapping[str, str]) -> MockPrompts:
         """Extend the existing list of questions and answers"""
         new_patterns_to_answers = {
             **{pattern.pattern: answer for pattern, answer in self._questions_to_answers},


### PR DESCRIPTION
This PR updates the type hints on the `Prompt` interface:

 - No more `Any` (which is never checked), instead generic type arguments are used.
 - The interface for `choice()` now specifies that the choices must be strings; the internal implementation assumed this anyway.
 - Read-only (collection) types are used instead of `dict[]` and `list[]`, indicating the arguments are not modified.

In addition, we now use (and allow) precompiled regexes for the `valid_regex` argument on `Prompt.question()`.

These changes are backwards compatible at runtime, and mostly backwards compatible for type-checking. The exception is the change to `Prompt.choice()`: if the `choices` argument was not known to be a sequence of strings, a type checker must now be able to infer this.