### PR TITLE
Dependabot cooldown: 7 days for python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
         - "databricks*"
     schedule:
       interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
+
+  # Disabled for now, pending
+  #- package-ecosystem: "github-actions"
+  #  directory: "/"
+  #  schedule:
+  #    interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "databricks*"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
This PR updates the dependabot configuration for this repository:

 - Python packages have a 7-day cooldown before a release is considered for an update. First-party packages (eg. `databricks-sdk`) are exempt from this.
 - Updates for actions have been disabled for now, pending an updated policy for when new versions should become available.