### PR TITLE
Limit GHA permissions, disable releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "daily"
 
-  # Disabled for now, pending
+  # Disabled for now, pending guidance on how GHA-updates need to be handled.
   #- package-ecosystem: "github-actions"
   #  directory: "/"
   #  schedule:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -5,14 +5,17 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 permissions:
-  id-token: write
   contents: read
-  pull-requests: write
 
 jobs:
   integration:
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     environment: runtime
+    permissions:
+      # Access to the integration testing infrastructure.
+      id-token: write
+      # Write test results to the PR.
+      pull-requests: write
     runs-on: larger
     steps:
       - name: Checkout Code

--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -15,9 +15,7 @@ on:
       - main
 
 permissions:
-  id-token: write
   contents: read
-  pull-requests: write
 
 jobs:
   compatibility:
@@ -29,6 +27,11 @@ jobs:
           - name: lsql
           - name: remorph
     runs-on: ubuntu-latest
+    permissions:
+      # Access to the integration testing infrastructure.
+      id-token: write
+      # Write test results to the PR.
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,8 +6,6 @@ on:
     - cron: '30 4 * * *'
 
 permissions:
-  id-token: write
-  issues: write
   contents: read
   pull-requests: read
 
@@ -17,6 +15,11 @@ concurrency:
 jobs:
   integration:
     environment: runtime
+    permissions:
+      # Access to the integration testing infrastructure.
+      id-token: write
+      # Create issues for failing tests
+      issues: write
     runs-on: larger
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  # Disabled for now, pending further work.
+  #push:
+  #  tags:
+  #    - 'v*'
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR updates the GHA workflows, to assist with review-by-inspection:

 - Non-read permissions are now scoped directly on the job that needs them, and the reason for their use is documented.
 - All the release triggers are disabled for now.

Progresses: #330