### PR TITLE
Limit OIDC to environment-protected workflows

### DIFF
--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -27,6 +27,7 @@ jobs:
           - name: lsql
           - name: remorph
     runs-on: ubuntu-latest
+    environment: runtime
     permissions:
       # Access to the integration testing infrastructure.
       id-token: write


### PR DESCRIPTION
This PR ensures that the downstream CI/CD checks do not run without being approved to access the `runtime` environment.

Progresses #330.