### PR TITLE
GitHub action updates for JFrog

### DIFF
--- a/.build-constraints.txt
+++ b/.build-constraints.txt
@@ -13,7 +13,7 @@ pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
     # via hatchling
-tomli==2.4.1 \
+tomli==2.4.1 ; python_full_version < '3.11' \
     --hash=sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853 \
     --hash=sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe \
     --hash=sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5 \

--- a/.github/actions/jfrog-auth/action.yml
+++ b/.github/actions/jfrog-auth/action.yml
@@ -1,0 +1,14 @@
+name: 'Authenticate for JFrog'
+description: 'Authenticate with JFrog using OIDC based on the GitHub repository.'
+outputs:
+  jfrog-access-token:
+    description: "Access token for JFrog"
+    value: "${{ steps.jfrog-auth.outputs.jfrog-access-token }}"
+runs:
+  using: "composite"
+  steps:
+    - id: jfrog-auth
+      name: Authenticate against JFrog
+      shell: bash
+      run: |
+        "${GITHUB_ACTION_PATH}/jfrog-auth" "${ACTIONS_ID_TOKEN_REQUEST_URL}" "${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"

--- a/.github/actions/jfrog-auth/jfrog-auth
+++ b/.github/actions/jfrog-auth/jfrog-auth
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Obtain a JFrog access token, assuming GitHub OIDC.
+#
+set -eu
+
+_request_url="$1"
+_request_token="$2"
+
+#
+# Step 1: Obtain the OIDC identifier token from GitHub.
+#
+printf '::debug::%s\n' "Fetching OIDC identifier token from GitHub..."
+_id_token="$(curl -sLS \
+    -H 'User-Agent: actions/oidc-client' \
+    -H "Authorization: Bearer ${_request_token}" \
+    "${_request_url}&audience=jfrog-github" |
+    jq -r .value)"
+printf '::add-mask::%s\n' "${_id_token}"
+
+#
+# Step 2: Exchange it for the JFrog access token.
+#
+printf '::debug::%s\n' "Exchanging OIDC identifier token for JFrog access token..."
+_access_token=$(curl -sLS \
+    --json "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${_id_token}\", \"provider_name\": \"github-actions\"}" \
+    "https://databricks.jfrog.io/access/api/v1/oidc/token" |
+    jq -r .access_token)
+printf '::add-mask::%s\n' "${_access_token}"
+
+if [ -z "${_access_token}" ] || [ "${_access_token}" = 'null' ]
+then
+    printf '::error::%s\n' "Could not fetch JFrog access token."
+    exit 1
+fi
+
+printf '%s=%s\n' 'jfrog-access-token' "${_access_token}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -16,7 +16,9 @@ jobs:
       id-token: write
       # Write test results to the PR.
       pull-requests: write
-    runs-on: larger
+    runs-on:
+      group: larger-runners
+      labels: larger
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -41,28 +41,7 @@ jobs:
       - name: Configure uv authentication for JFrog
         env:
           JFROG_ACCESS_TOKEN: "${{ steps.jfrog-auth.outputs.jfrog-access-token }}"
-        run: |
-          find "$(uv auth dir)" -ls || printf "No auth dir before\n"
-          uv auth login "${UV_INDEX_URL}" --username gha-service-account --password "${JFROG_ACCESS_TOKEN}"
-          find "$(uv auth dir)" -ls || printf "No auth dir after\n"
-
-      - name: Debug pre_setup
-        run: |
-          set -ex
-          which make
-          which uv
-          uv --version
-          make dev
-          ls -la .venv/bin/python
-          .venv/bin/python -c "import pytest; print(pytest.__version__)"
-          .venv/bin/python -c "import databricks.labs.blueprint; print('project importable')"
-          cd tests/integration && ../../.venv/bin/python -c "
-          import pytest
-          class C:
-              def pytest_sessionfinish(self, session):
-                  print(f'Collected {len(session.items)} tests')
-          pytest.main(['--collect-only', '-q'], plugins=[C()])
-          "
+        run: uv auth login "${UV_INDEX_URL}" --username gha-service-account --password "${JFROG_ACCESS_TOKEN}"
 
       - name: Acceptance
         uses: databrickslabs/sandbox/acceptance@3313d06ce86227537b3f37f5974f7eecb2a8e59a  # acceptance/v0.4.4

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -12,13 +12,16 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     environment: runtime
     permissions:
-      # Access to the integration testing infrastructure.
+      # Access to JFrog and the integration testing infrastructure.
       id-token: write
       # Write test results to the PR.
       pull-requests: write
     runs-on:
       group: larger-runners
       labels: larger
+    env:
+      UV_FROZEN: 1
+      UV_INDEX_URL: https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple  # Authentication needed, below.
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -30,6 +33,36 @@ jobs:
         with:
           version: "0.11.2"
           checksum: "7ac2ca0449c8d68dae9b99e635cd3bc9b22a4cb1de64b7c43716398447d42981"  # uv-x86_64-unknown-linux-gnu.tar.gz
+
+      - name: Authenticate against JFrog
+        id: jfrog-auth
+        uses: ./.github/actions/jfrog-auth
+
+      - name: Configure uv authentication for JFrog
+        env:
+          JFROG_ACCESS_TOKEN: "${{ steps.jfrog-auth.outputs.jfrog-access-token }}"
+        run: |
+          find "$(uv auth dir)" -ls || printf "No auth dir before\n"
+          uv auth login "${UV_INDEX_URL}" --username gha-service-account --password "${JFROG_ACCESS_TOKEN}"
+          find "$(uv auth dir)" -ls || printf "No auth dir after\n"
+
+      - name: Debug pre_setup
+        run: |
+          set -ex
+          which make
+          which uv
+          uv --version
+          make dev
+          ls -la .venv/bin/python
+          .venv/bin/python -c "import pytest; print(pytest.__version__)"
+          .venv/bin/python -c "import databricks.labs.blueprint; print('project importable')"
+          cd tests/integration && ../../.venv/bin/python -c "
+          import pytest
+          class C:
+              def pytest_sessionfinish(self, session):
+                  print(f'Collected {len(session.items)} tests')
+          pytest.main(['--collect-only', '-q'], plugins=[C()])
+          "
 
       - name: Acceptance
         uses: databrickslabs/sandbox/acceptance@3313d06ce86227537b3f37f5974f7eecb2a8e59a  # acceptance/v0.4.4

--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -26,7 +26,9 @@ jobs:
           - name: ucx
           - name: lsql
           - name: remorph
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: runtime
     permissions:
       # Access to the integration testing infrastructure.

--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -31,10 +31,13 @@ jobs:
       labels: linux-ubuntu-latest
     environment: runtime
     permissions:
-      # Access to the integration testing infrastructure.
+      # Access to JFrog and the integration testing infrastructure.
       id-token: write
       # Write test results to the PR.
       pull-requests: write
+    env:
+      UV_FROZEN: 1
+      UV_INDEX_URL: https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple  # Authentication needed, below.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -46,6 +49,15 @@ jobs:
         with:
           version: "0.11.2"
           checksum: "7ac2ca0449c8d68dae9b99e635cd3bc9b22a4cb1de64b7c43716398447d42981"  # uv-x86_64-unknown-linux-gnu.tar.gz
+
+      - name: Authenticate against JFrog
+        id: jfrog-auth
+        uses: ./.github/actions/jfrog-auth
+
+      - name: Configure uv authentication for JFrog
+        env:
+          JFROG_ACCESS_TOKEN: "${{ steps.jfrog-auth.outputs.jfrog-access-token }}"
+        run: uv auth login "${UV_INDEX_URL}" --username gha-service-account --password "${JFROG_ACCESS_TOKEN}"
 
       - name: Acceptance
         uses: databrickslabs/sandbox/downstreams@3313d06ce86227537b3f37f5974f7eecb2a8e59a  # acceptance/v0.4.4

--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -60,9 +60,10 @@ jobs:
         run: uv auth login "${UV_INDEX_URL}" --username gha-service-account --password "${JFROG_ACCESS_TOKEN}"
 
       - name: Acceptance
-        uses: databrickslabs/sandbox/downstreams@3313d06ce86227537b3f37f5974f7eecb2a8e59a  # acceptance/v0.4.4
-        with:
-          repo: ${{ matrix.downstream.name }}
-          org: databrickslabs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: printf '::error::%s\n' "Downstream tests disabled pending repository lockdown."
+      #  uses: databrickslabs/sandbox/downstreams@3313d06ce86227537b3f37f5974f7eecb2a8e59a  # acceptance/v0.4.4
+      #  with:
+      #    repo: ${{ matrix.downstream.name }}
+      #    org: databrickslabs
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,9 @@ jobs:
       id-token: write
       # Create issues for failing tests
       issues: write
-    runs-on: larger
+    runs-on:
+      group: larger-runners
+      labels: larger
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,13 +16,16 @@ jobs:
   integration:
     environment: runtime
     permissions:
-      # Access to the integration testing infrastructure.
+      # Access to JFrog and the integration testing infrastructure.
       id-token: write
       # Create issues for failing tests
       issues: write
     runs-on:
       group: larger-runners
       labels: larger
+    env:
+      UV_FROZEN: 1
+      UV_INDEX_URL: https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple  # Authentication needed, below.
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -34,6 +37,15 @@ jobs:
         with:
           version: "0.11.2"
           checksum: "7ac2ca0449c8d68dae9b99e635cd3bc9b22a4cb1de64b7c43716398447d42981"  # uv-x86_64-unknown-linux-gnu.tar.gz
+
+      - name: Authenticate against JFrog
+        id: jfrog-auth
+        uses: ./.github/actions/jfrog-auth
+
+      - name: Configure uv authentication for JFrog
+        env:
+          JFROG_ACCESS_TOKEN: "${{ steps.jfrog-auth.outputs.jfrog-access-token }}"
+        run: uv auth login "${UV_INDEX_URL}" --username gha-service-account --password "${JFROG_ACCESS_TOKEN}"
 
       - name: Run nightly tests
         uses: databrickslabs/sandbox/acceptance@3313d06ce86227537b3f37f5974f7eecb2a8e59a  # acceptance/v0.4.4

--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -9,7 +9,9 @@ permissions:
 
 jobs:
   no-pylint-disable:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,7 +26,11 @@ jobs:
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
+    permissions:
+      id-token: write  # JFrog OIDC
     env:
+      UV_FROZEN: 1
+      UV_INDEX_URL: https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple  # Authentication needed, below.
       UV_PYTHON: "${{ matrix.python }}"
     steps:
       - name: Checkout
@@ -37,6 +41,15 @@ jobs:
         with:
           version: "0.11.2"
           checksum: "7ac2ca0449c8d68dae9b99e635cd3bc9b22a4cb1de64b7c43716398447d42981"  # uv-x86_64-unknown-linux-gnu.tar.gz
+
+      - name: Authenticate against JFrog
+        id: jfrog-auth
+        uses: ./.github/actions/jfrog-auth
+
+      - name: Configure uv authentication for JFrog
+        env:
+          JFROG_ACCESS_TOKEN: "${{ steps.jfrog-auth.outputs.jfrog-access-token }}"
+        run: uv auth login "${UV_INDEX_URL}" --username gha-service-account --password "${JFROG_ACCESS_TOKEN}"
 
       - name: Initialize the project
         run: make dev
@@ -53,6 +66,11 @@ jobs:
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
+    permissions:
+      id-token: write  # JFrog OIDC
+    env:
+      UV_FROZEN: 1
+      UV_INDEX_URL: https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple  # Authentication needed, below.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -62,6 +80,15 @@ jobs:
         with:
           version: "0.11.2"
           checksum: "7ac2ca0449c8d68dae9b99e635cd3bc9b22a4cb1de64b7c43716398447d42981"  # uv-x86_64-unknown-linux-gnu.tar.gz
+
+      - name: Authenticate against JFrog
+        id: jfrog-auth
+        uses: ./.github/actions/jfrog-auth
+
+      - name: Configure uv authentication for JFrog
+        env:
+          JFROG_ACCESS_TOKEN: "${{ steps.jfrog-auth.outputs.jfrog-access-token }}"
+        run: uv auth login "${UV_INDEX_URL}" --username gha-service-account --password "${JFROG_ACCESS_TOKEN}"
 
       - name: Initialize the project
         run: make dev

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         python: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
     env:
       UV_PYTHON: "${{ matrix.python }}"
     steps:
@@ -48,7 +50,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   fmt:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,13 @@ jobs:
       labels: linux-ubuntu-latest
     environment: release
     permissions:
-      # Used to authenticate to PyPI via OIDC and sign the release's artifacts with sigstore-python.
+      # Used to access JFrog, authenticate to PyPI via OIDC and sign the release's artifacts with sigstore-python.
       id-token: write
       # Used to attach signing artifacts to the published release.
       contents: write
+    env:
+      UV_FROZEN: 1
+      UV_INDEX_URL: https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple  # Authentication needed, below.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -28,6 +31,15 @@ jobs:
         with:
           version: "0.11.2"
           checksum: "7ac2ca0449c8d68dae9b99e635cd3bc9b22a4cb1de64b7c43716398447d42981"  # uv-x86_64-unknown-linux-gnu.tar.gz
+
+      - name: Authenticate against JFrog
+        id: jfrog-auth
+        uses: ./.github/actions/jfrog-auth
+
+      - name: Configure uv authentication for JFrog
+        env:
+          JFROG_ACCESS_TOKEN: "${{ steps.jfrog-auth.outputs.jfrog-access-token }}"
+        run: uv auth login "${UV_INDEX_URL}" --username gha-service-account --password "${JFROG_ACCESS_TOKEN}"
 
       - name: Build wheels
         run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-on:
+on: {}
   # Disabled for now, pending further work.
   #push:
   #  tags:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ lock-dependencies: UV_LOCKED := 0
 lock-dependencies:
 	uv lock
 	$(UV_RUN) --group yq tomlq -r '.["build-system"].requires[]' pyproject.toml | \
-	    uv pip compile --generate-hashes --no-header - > .build-constraints.txt
+	    uv pip compile --generate-hashes --universal --no-header - > build-constraints-new.txt
+	mv build-constraints-new.txt .build-constraints.txt
 
 .DEFAULT: all
 .PHONY: all clean dev lint fmt test integration coverage build lock-dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 all: clean lint fmt test coverage
 
-# Ensure that all uv commands are locked and don't automatically update the lock file.
+# Ensure that all uv commands don't automatically update the lock file. If UV_FROZEN=1 (from the environment)
+# then UV_LOCKED should _not_ be set, but otherwise it needs to be set to ensure the lock-file is only ever
+# deliberately updated.
+ifneq ($(UV_FROZEN),1)
 export UV_LOCKED := 1
+endif
+# Ensure that hatchling is pinned when builds are needed.
+export UV_BUILD_CONSTRAINT := .build-constraints.txt
 
 UV_RUN := uv run --exact --all-extras
 UV_TEST := $(UV_RUN) pytest -n 4 --timeout 30 --durations 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ pytest = [
 test = [
     { include-group = "pytest" },
 ]
-# Ensure we can use yq in a way that it (and dependencies) are subject to the cooldown policy.
+# Ensure we can use yq in a way that it (and dependencies) are pinned.
 yq = [
     "yq~=3.4.3"
 ]
@@ -110,8 +110,6 @@ line-length = 120
 known-first-party = ["databricks.labs.blueprint"]
 
 [tool.uv]
-exclude-newer = "7 days"
-exclude-newer-package = { "databricks-sdk" = false }
 required-version = "~= 0.11.0"
 
 [tool.pylint.main]

--- a/uv.lock
+++ b/uv.lock
@@ -7,13 +7,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "2026-03-26T11:56:54.165855Z"
-exclude-newer-span = "P7D"
-
-[options.exclude-newer-package]
-databricks-sdk = false
-
 [[package]]
 name = "argcomplete"
 version = "3.6.3"


### PR DESCRIPTION
This PR updates the GHA workflows, specifically:

 - Workflows all run on the managed runners.
 - Access to JFrog has been set up for accessing dependencies.

Some incidental changes:

 - Fixed a mistake in `release.yml` whereby it didn't conform to the schema.
 - The cooldown configuration for uv has been removed: this is incompatible with JFrog.
 - Downstream checks have been disabled: they depend on hatch, which we're not using. Once those projects have been updated these downstream checks will be re-enabled. 

Progresses: #330

Note: CI/CD checks still fail, for various reasons:

 - Unit tests fail, addressed in #331.
 - Allow-lists for infrastructure prevent the integration tests from completing properly.