### PR TITLE
GitHub action: shell escaping

### DIFF
--- a/.github/workflows/no-cheat.yml
+++ b/.github/workflows/no-cheat.yml
@@ -18,10 +18,10 @@ jobs:
 
       - name: Verify no lint is disabled in the new code
         run: |
-          git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
-          git diff $GITHUB_BASE_REF...$(git branch --show-current) >> diff_data.txt
+          git fetch origin "${GITHUB_BASE_REF}:${GITHUB_BASE_REF}"
+          git diff "${GITHUB_BASE_REF}...$(git branch --show-current)" >> diff_data.txt
           python tests/unit/no_cheat.py diff_data.txt >> cheats.txt
-          COUNT=$(cat cheats.txt | wc -c)
+          COUNT="$(cat cheats.txt | wc -c)"
           if [ ${COUNT} -gt 1 ]; then
             cat cheats.txt
             exit 1


### PR DESCRIPTION
This PR updates one of our workflows: the embedded shell commands weren't surrounding variable expansion with quotes, which could lead to incorrect commands being executed.