### PR TITLE
Dependabot: batch patch-level updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     schedule:
       interval: "daily"
     groups:
+      # Patch-level updates are low-risk, and can be batched together into a single PR to reduce update noise.
       batch-patch-updates:
         update-types:
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
         - "databricks*"
     schedule:
       interval: "daily"
+    groups:
+      batch-patch-updates:
+        update-types:
+          - "patch"
 
   # Disabled for now, pending guidance on how GHA-updates need to be handled.
   #- package-ecosystem: "github-actions"


### PR DESCRIPTION
This PR updates the dependabot policy so that patch-level updates are grouped. These are generally low-risk, and grouping them reduces PR/update noise.